### PR TITLE
Remove redundant STATICFILES_DIRS.

### DIFF
--- a/city-infrastructure-platform/settings.py
+++ b/city-infrastructure-platform/settings.py
@@ -152,7 +152,6 @@ STATIC_ROOT = var_root("static")
 MEDIA_URL = "/media/"
 STATIC_URL = "/static/"
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
-STATICFILES_DIRS = [checkout_dir("static")]
 
 # Django REST Framework
 REST_FRAMEWORK = {


### PR DESCRIPTION
Remove redundant STATICFILES_DIRS so that _ manage.py collectstatic_ works also without static-folder.