### PR TITLE
Add IsAdminOrReadOnly permission

### DIFF
--- a/traffic_control/permissions.py
+++ b/traffic_control/permissions.py
@@ -1,0 +1,7 @@
+from rest_framework.permissions import IsAdminUser, SAFE_METHODS
+
+
+class IsAdminUserOrReadOnly(IsAdminUser):
+    def has_permission(self, request, view):
+        is_admin = super().has_permission(request, view)
+        return request.method in SAFE_METHODS or is_admin

--- a/traffic_control/tests/test_permissions.py
+++ b/traffic_control/tests/test_permissions.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.test import RequestFactory
+
+from traffic_control.permissions import IsAdminUserOrReadOnly
+
+mock_view = MagicMock()
+mock_user = MagicMock()
+
+
+@pytest.mark.parametrize(
+    "method,is_staff,expected",
+    [
+        ["get", False, True],
+        ["get", True, True],
+        ["head", False, True],
+        ["head", True, True],
+        ["options", False, True],
+        ["options", True, True],
+        ["post", False, False],
+        ["post", True, True],
+        ["patch", False, False],
+        ["patch", True, True],
+        ["put", False, False],
+        ["put", True, True],
+    ],
+)
+def test_is_admin_user_or_read_only(method, is_staff, expected):
+    request = RequestFactory().generic(method=method, path="/")
+    request.user = mock_user
+    request.user.is_staff = is_staff
+    assert IsAdminUserOrReadOnly().has_permission(request, mock_view) == expected

--- a/traffic_control/views.py
+++ b/traffic_control/views.py
@@ -128,7 +128,7 @@ class TrafficSignCodeViewSet(ModelViewSet):
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = "__all__"
     ordering = ["code"]
-    permission_classes = [IsAdminUser]
+    permission_classes = [IsAdminUserOrReadOnly]
     serializer_class = TrafficSignCodeSerializer
     queryset = TrafficSignCode.objects.all()
     filterset_class = TrafficSignCodeFilterSet

--- a/traffic_control/views.py
+++ b/traffic_control/views.py
@@ -1,6 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
-from rest_framework.permissions import IsAdminUser, IsAuthenticatedOrReadOnly
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.viewsets import ModelViewSet
 
 from traffic_control.filters import (
@@ -36,6 +36,7 @@ from traffic_control.models import (
     TrafficSignPlan,
     TrafficSignReal,
 )
+from traffic_control.permissions import IsAdminUserOrReadOnly
 from traffic_control.serializers import (
     BarrierPlanSerializer,
     BarrierRealSerializer,
@@ -149,7 +150,7 @@ class PortalTypeViewSet(ModelViewSet):
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = "__all__"
     ordering = ["structure", "build_type", "model"]
-    permission_classes = [IsAdminUser]
+    permission_classes = [IsAdminUserOrReadOnly]
     serializer_class = PortalTypeSerializer
     queryset = PortalType.objects.all()
     filterset_class = PortalTypeFilterSet


### PR DESCRIPTION
- Permission class to allow editing for admins, but only read access for others
- Add that permission class to portal types and traffic sign codes views
- Tests
- Test naming refactoring

Refs: LIIK-60