### PR TITLE
Sentry integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ SECRET_KEY=change-me
 DATABASE_URL=postgis://city-infrastructure-platform:city-infrastructure-platform@localhost/city-infrastructure-platform
 ALLOWED_HOSTS=127.0.0.1,localhost
 AZURE_DEPLOYMENT=False
+SENTRY_DSN=need-sentry

--- a/city-infrastructure-platform/settings.py
+++ b/city-infrastructure-platform/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 
 import environ
-import raven
 from django.utils.translation import gettext_lazy as _  # NOQA
 
 # Set up .env file
@@ -41,11 +40,6 @@ env = environ.Env(
 if os.path.exists(env_file):
     env.read_env(env_file)
 
-try:
-    version = raven.fetch_git_sha(checkout_dir())
-except Exception:
-    version = None
-
 # General settings
 DEBUG = env.bool("DEBUG")
 TIER = env.str("TIER")
@@ -57,7 +51,6 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 
 CACHES = {"default": env.cache()}
 vars().update(env.email_url())  # EMAIL_BACKEND etc.
-RAVEN_CONFIG = {"dsn": env.str("SENTRY_DSN"), "release": version}
 
 # Application definition
 DJANGO_APPS = [
@@ -70,7 +63,6 @@ DJANGO_APPS = [
     "django.contrib.gis",
 ]
 THIRD_PARTY_APPS = [
-    "raven.contrib.django.raven_compat",
     "django_extensions",
     "rest_framework",
     "rest_framework_gis",

--- a/city-infrastructure-platform/settings.py
+++ b/city-infrastructure-platform/settings.py
@@ -11,7 +11,9 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 
 import environ
+import sentry_sdk
 from django.utils.translation import gettext_lazy as _  # NOQA
+from sentry_sdk.integrations.django import DjangoIntegration
 
 # Set up .env file
 checkout_dir = environ.Path(__file__) - 2
@@ -161,6 +163,11 @@ if DEBUG:
 
 # Azure CLIENT_IP middleware
 AZURE_DEPLOYMENT = env.bool("AZURE_DEPLOYMENT")
+
+# Sentry-SDK
+SENTRY_DSN = env.str("SENTRY_DSN")
+if SENTRY_DSN:
+    sentry_sdk.init(dsn=SENTRY_DSN, integrations=[DjangoIntegration()])
 
 # Custom settings
 SRID = 3879  # the spatial reference id used for geometries

--- a/city-infrastructure-platform/settings.py
+++ b/city-infrastructure-platform/settings.py
@@ -15,6 +15,8 @@ import sentry_sdk
 from django.utils.translation import gettext_lazy as _  # NOQA
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from .utils import git_version
+
 # Set up .env file
 checkout_dir = environ.Path(__file__) - 2
 assert os.path.exists(checkout_dir("manage.py"))
@@ -166,8 +168,9 @@ AZURE_DEPLOYMENT = env.bool("AZURE_DEPLOYMENT")
 
 # Sentry-SDK
 SENTRY_DSN = env.str("SENTRY_DSN")
+VERSION = git_version()
 if SENTRY_DSN:
-    sentry_sdk.init(dsn=SENTRY_DSN, integrations=[DjangoIntegration()])
+    sentry_sdk.init(dsn=SENTRY_DSN, integrations=[DjangoIntegration()], release=VERSION)
 
 # Custom settings
 SRID = 3879  # the spatial reference id used for geometries

--- a/city-infrastructure-platform/urls.py
+++ b/city-infrastructure-platform/urls.py
@@ -82,6 +82,8 @@ urlpatterns = i18n_patterns(
     ),
 )
 
+urlpatterns.append(path("sentry-debug/", lambda a: 1 / 0))
+
 if settings.DEBUG:
     from django.conf.urls.static import static
 

--- a/city-infrastructure-platform/utils.py
+++ b/city-infrastructure-platform/utils.py
@@ -1,0 +1,63 @@
+"""
+Copyright (c) 2005-2019, NumPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the NumPy Developers nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+import os
+import subprocess
+
+
+# Return the git revision as a string
+def git_version():
+    def _minimal_ext_cmd(cmd):
+        # construct minimal environment
+        env = {}
+        for k in ["SYSTEMROOT", "PATH", "HOME"]:
+            v = os.environ.get(k)
+            if v is not None:
+                env[k] = v
+        # LANGUAGE is used on win32
+        env["LANGUAGE"] = "C"
+        env["LANG"] = "C"
+        env["LC_ALL"] = "C"
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=env)
+        return out
+
+    try:
+        out = _minimal_ext_cmd(["git", "rev-parse", "HEAD"])
+        git_revision = out.strip().decode("ascii")
+    except (subprocess.SubprocessError, OSError):
+        git_revision = "Unknown"
+
+    if not git_revision:
+        # this shouldn't happen but apparently can
+        git_revision = "Unknown"
+
+    return git_revision

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ pytz==2019.3
 requests==2.22.0
 ruamel.yaml==0.16.5
 ruamel.yaml.clib==0.2.0
+sentry-sdk==0.14.1
 six==1.13.0
 sqlparse==0.3.0
 uritemplate==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ psycopg2==2.8.4
 pyparsing==2.4.6
 python-dateutil==2.6.0
 pytz==2019.3
-raven==6.10.0
 requests==2.22.0
 ruamel.yaml==0.16.5
 ruamel.yaml.clib==0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ requirements =
 	pytz
 	--no-binary psycopg2
 	psycopg2
-	raven~=6.10.0
 	requests
 	django-extensions
 	django-filter

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ requirements =
 	drf_yasg
 	djangorestframework-gis
 	django-auditlog
+	sentry-sdk
 requirements-dev =
 	autoflake
 	autopep8


### PR DESCRIPTION
Raven is currently phasing out in favor of Sentry SDK, which also
supports newest versions of Python and Django. Our project will be
updated to Django 3 later, so we want to use packages that support
that.

- Remove Raven
- Add Sentry SDK
- Configure Sentry SDK in settings
- Add debug path for sentry

Refs: LIIK-54