### PR TITLE
Feature/geojson url param

### DIFF
--- a/city-infrastructure-platform/settings.py
+++ b/city-infrastructure-platform/settings.py
@@ -69,7 +69,6 @@ DJANGO_APPS = [
 THIRD_PARTY_APPS = [
     "django_extensions",
     "rest_framework",
-    "rest_framework_gis",
     "corsheaders",
     "drf_yasg",
     "django_filters",

--- a/traffic_control/serializers.py
+++ b/traffic_control/serializers.py
@@ -1,5 +1,6 @@
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 from rest_framework import serializers
+from rest_framework_gis.fields import GeometryField
 
 from traffic_control.models import (
     BarrierPlan,
@@ -40,6 +41,10 @@ class TrafficLightPlanSerializer(
         )
 
 
+class TrafficLightPlanGeoJSONSerializer(TrafficLightPlanSerializer):
+    location = GeometryField()
+
+
 class TrafficLightRealSerializer(
     EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
@@ -53,6 +58,10 @@ class TrafficSignPlanUploadSerializer(serializers.ModelSerializer):
     class Meta:
         model = TrafficSignPlan
         fields = ("plan_document",)
+
+
+class TrafficLightRealGeoJSONSerializer(TrafficLightRealSerializer):
+    location = GeometryField()
 
 
 class TrafficSignPlanSerializer(
@@ -70,6 +79,11 @@ class TrafficSignPlanSerializer(
         )
 
 
+class TrafficSignPlanGeoJSONSerializer(TrafficSignPlanSerializer):
+    location = GeometryField()
+    affect_area = GeometryField()
+
+
 class TrafficSignRealSerializer(
     EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
@@ -85,6 +99,11 @@ class SignpostPlanUploadSerializer(serializers.ModelSerializer):
         fields = ("plan_document",)
 
 
+class TrafficSignRealGeoJSONSerializer(TrafficSignRealSerializer):
+    location = GeometryField()
+    affect_area = GeometryField()
+
+
 class SignpostPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = SignpostPlan
@@ -96,6 +115,10 @@ class SignpostPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerial
             "deleted_at",
             "plan_document",
         )
+
+
+class SignpostPlanGeoJSONSerializer(SignpostPlanSerializer):
+    location = GeometryField()
 
 
 class SignpostRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
@@ -111,6 +134,10 @@ class MountPlanUploadSerializer(serializers.ModelSerializer):
         fields = ("plan_document",)
 
 
+class SignpostRealGeoJSONSerializer(SignpostRealSerializer):
+    location = GeometryField()
+
+
 class MountPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = MountPlan
@@ -122,6 +149,10 @@ class MountPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerialize
             "deleted_at",
             "plan_document",
         )
+
+
+class MountPlanGeoJSONSerializer(MountPlanSerializer):
+    location = GeometryField()
 
 
 class MountRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
@@ -137,6 +168,10 @@ class BarrierPlanUploadSerializer(serializers.ModelSerializer):
         fields = ("plan_document",)
 
 
+class MountRealGeoJSONSerializer(MountRealSerializer):
+    location = GeometryField()
+
+
 class BarrierPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = BarrierPlan
@@ -150,6 +185,10 @@ class BarrierPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSeriali
         )
 
 
+class BarrierPlanGeoJSONSerializer(BarrierPlanSerializer):
+    location = GeometryField()
+
+
 class BarrierRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = BarrierReal
@@ -161,6 +200,10 @@ class RoadMarkingPlanUploadSerializer(serializers.ModelSerializer):
     class Meta:
         model = RoadMarkingPlan
         fields = ("plan_document",)
+
+
+class BarrierRealGeoJSONSerializer(BarrierRealSerializer):
+    location = GeometryField()
 
 
 class RoadMarkingPlanSerializer(
@@ -178,6 +221,10 @@ class RoadMarkingPlanSerializer(
         )
 
 
+class RoadMarkingPlanGeoJSONSerializer(RoadMarkingPlanSerializer):
+    location = GeometryField()
+
+
 class RoadMarkingRealSerializer(
     EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
@@ -185,6 +232,10 @@ class RoadMarkingRealSerializer(
         model = RoadMarkingReal
         fields = "__all__"
         read_only_fields = ("created_by", "updated_by", "deleted_by", "deleted_at")
+
+
+class RoadMarkingRealGeoJSONSerializer(RoadMarkingRealSerializer):
+    location = GeometryField()
 
 
 class TrafficSignCodeSerializer(serializers.ModelSerializer):

--- a/traffic_control/views.py
+++ b/traffic_control/views.py
@@ -41,25 +41,37 @@ from traffic_control.models import (
 )
 from traffic_control.permissions import IsAdminUserOrReadOnly
 from traffic_control.serializers import (
+    BarrierPlanGeoJSONSerializer,
     BarrierPlanSerializer,
     BarrierPlanUploadSerializer,
+    BarrierRealGeoJSONSerializer,
     BarrierRealSerializer,
+    MountPlanGeoJSONSerializer,
     MountPlanSerializer,
     MountPlanUploadSerializer,
+    MountRealGeoJSONSerializer,
     MountRealSerializer,
     PortalTypeSerializer,
+    RoadMarkingPlanGeoJSONSerializer,
     RoadMarkingPlanSerializer,
     RoadMarkingPlanUploadSerializer,
+    RoadMarkingRealGeoJSONSerializer,
     RoadMarkingRealSerializer,
+    SignpostPlanGeoJSONSerializer,
     SignpostPlanSerializer,
     SignpostPlanUploadSerializer,
+    SignpostRealGeoJSONSerializer,
     SignpostRealSerializer,
+    TrafficLightPlanGeoJSONSerializer,
     TrafficLightPlanSerializer,
     TrafficLightPlanUploadSerializer,
+    TrafficLightRealGeoJSONSerializer,
     TrafficLightRealSerializer,
     TrafficSignCodeSerializer,
+    TrafficSignPlanGeoJSONSerializer,
     TrafficSignPlanSerializer,
     TrafficSignPlanUploadSerializer,
+    TrafficSignRealGeoJSONSerializer,
     TrafficSignRealSerializer,
 )
 
@@ -71,10 +83,20 @@ class TrafficControlViewSet(
     ordering_fields = "__all__"
     ordering = ["-created_at"]
     permission_classes = [IsAuthenticatedOrReadOnly]
+    serializer_classes = {}
+
+    def get_serializer_class(self):
+        geo_format = self.request.query_params.get("geo_format")
+        if geo_format == "geojson":
+            return self.serializer_classes.get("geojson")
+        return self.serializer_classes.get("default")
 
 
 class BarrierPlanViewSet(TrafficControlViewSet):
-    serializer_class = BarrierPlanSerializer
+    serializer_classes = {
+        "default": BarrierPlanSerializer,
+        "geojson": BarrierPlanGeoJSONSerializer,
+    }
     queryset = BarrierPlan.objects.all()
     filterset_class = BarrierPlanFilterSet
 
@@ -95,12 +117,19 @@ class BarrierPlanViewSet(TrafficControlViewSet):
 
 
 class BarrierRealViewSet(TrafficControlViewSet):
-    serializer_class = BarrierRealSerializer
+    serializer_classes = {
+        "default": BarrierRealSerializer,
+        "geojson": BarrierRealGeoJSONSerializer,
+    }
     queryset = BarrierReal.objects.all()
     filterset_class = BarrierRealFilterSet
 
 
 class MountPlanViewSet(TrafficControlViewSet):
+    serializer_classes = {
+        "default": MountPlanSerializer,
+        "geojson": MountPlanGeoJSONSerializer,
+    }
     serializer_class = MountPlanSerializer
     queryset = MountPlan.objects.all()
     filterset_class = MountPlanFilterSet
@@ -122,13 +151,20 @@ class MountPlanViewSet(TrafficControlViewSet):
 
 
 class MountRealViewSet(TrafficControlViewSet):
+    serializer_classes = {
+        "default": MountRealSerializer,
+        "geojson": MountRealGeoJSONSerializer,
+    }
     serializer_class = MountRealSerializer
     queryset = MountReal.objects.all()
     filterset_class = MountRealFilterSet
 
 
 class RoadMarkingPlanViewSet(TrafficControlViewSet):
-    serializer_class = RoadMarkingPlanSerializer
+    serializer_classes = {
+        "default": RoadMarkingPlanSerializer,
+        "geojson": RoadMarkingPlanGeoJSONSerializer,
+    }
     queryset = RoadMarkingPlan.objects.all()
     filterset_class = RoadMarkingPlanFilterSet
 
@@ -149,13 +185,19 @@ class RoadMarkingPlanViewSet(TrafficControlViewSet):
 
 
 class RoadMarkingRealViewSet(TrafficControlViewSet):
-    serializer_class = RoadMarkingRealSerializer
+    serializer_classes = {
+        "default": RoadMarkingRealSerializer,
+        "geojson": RoadMarkingRealGeoJSONSerializer,
+    }
     queryset = RoadMarkingReal.objects.all()
     filterset_class = RoadMarkingRealFilterSet
 
 
 class SignpostPlanViewSet(TrafficControlViewSet):
-    serializer_class = SignpostPlanSerializer
+    serializer_classes = {
+        "default": SignpostPlanSerializer,
+        "geojson": SignpostPlanGeoJSONSerializer,
+    }
     queryset = SignpostPlan.objects.all()
     filterset_class = SignpostPlanFilterSet
 
@@ -176,13 +218,19 @@ class SignpostPlanViewSet(TrafficControlViewSet):
 
 
 class SignpostRealViewSet(TrafficControlViewSet):
-    serializer_class = SignpostRealSerializer
+    serializer_classes = {
+        "default": SignpostRealSerializer,
+        "geojson": SignpostRealGeoJSONSerializer,
+    }
     queryset = SignpostReal.objects.all()
     filterset_class = SignpostRealFilterSet
 
 
 class TrafficLightPlanViewSet(TrafficControlViewSet):
-    serializer_class = TrafficLightPlanSerializer
+    serializer_classes = {
+        "default": TrafficLightPlanSerializer,
+        "geojson": TrafficLightPlanGeoJSONSerializer,
+    }
     queryset = TrafficLightPlan.objects.all()
     filterset_class = TrafficLightPlanFilterSet
 
@@ -203,7 +251,10 @@ class TrafficLightPlanViewSet(TrafficControlViewSet):
 
 
 class TrafficLightRealViewSet(TrafficControlViewSet):
-    serializer_class = TrafficLightRealSerializer
+    serializer_classes = {
+        "default": TrafficLightRealSerializer,
+        "geojson": TrafficLightRealGeoJSONSerializer,
+    }
     queryset = TrafficLightReal.objects.all()
     filterset_class = TrafficLightRealFilterSet
 
@@ -219,7 +270,10 @@ class TrafficSignCodeViewSet(ModelViewSet):
 
 
 class TrafficSignPlanViewSet(TrafficControlViewSet):
-    serializer_class = TrafficSignPlanSerializer
+    serializer_classes = {
+        "default": TrafficSignPlanSerializer,
+        "geojson": TrafficSignPlanGeoJSONSerializer,
+    }
     queryset = TrafficSignPlan.objects.all()
     filterset_class = TrafficSignPlanFilterSet
 
@@ -240,7 +294,10 @@ class TrafficSignPlanViewSet(TrafficControlViewSet):
 
 
 class TrafficSignRealViewSet(TrafficControlViewSet):
-    serializer_class = TrafficSignRealSerializer
+    serializer_classes = {
+        "default": TrafficSignRealSerializer,
+        "geojson": TrafficSignRealGeoJSONSerializer,
+    }
     queryset = TrafficSignReal.objects.all()
     filterset_class = TrafficSignRealFilterSet
 


### PR DESCRIPTION
We wanted to have the API output location format conditionally using
query parameters. Also the default location output of the API was unexpectedly
change to GeoJSON, which we are fixing here.

- Add GeoJSON serializers
- Tests to cover GeoJSON and EWKT API output
- Remove rest_framework_gis from the installed apps

Refs: LIIK-66, LIIK-63