### PR TITLE
Change static document root to MEDIA_ROOT

### DIFF
--- a/city-infrastructure-platform/urls.py
+++ b/city-infrastructure-platform/urls.py
@@ -87,4 +87,4 @@ urlpatterns.append(path("sentry-debug/", lambda a: 1 / 0))
 if settings.DEBUG:
     from django.conf.urls.static import static
 
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_URL)
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Uploaded media files were not working correctly, and we noticed that
document root for media was defined as a MEDIA_URL and not MEDIA_ROOT
as it should.

Refs: LIIK-56