### PR TITLE
Enable 3d Point editing for TrafficSignPlan and TrafficeSignReal admins

### DIFF
--- a/traffic_control/admin.py
+++ b/traffic_control/admin.py
@@ -4,6 +4,8 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from .forms import TrafficSignPlanModelForm, TrafficSignRealModelForm
+from .mixins import Point3DFieldAdminMixin
 from .models import (
     BarrierPlan,
     BarrierReal,
@@ -101,7 +103,49 @@ class TrafficLightRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
 
 
 @admin.register(TrafficSignPlan)
-class TrafficSignPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class TrafficSignPlanAdmin(
+    Point3DFieldAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
+):
+    form = TrafficSignPlanModelForm
+    fields = (
+        ("location", "z_coord"),
+        "height",
+        "direction",
+        "code",
+        "value",
+        "parent",
+        "order",
+        "txt",
+        "mount_plan",
+        "mount_type",
+        "mount_type_fi",
+        "decision_date",
+        "decision_id",
+        "plan_document",
+        "validity_period_start",
+        "validity_period_end",
+        "affect_area",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "created_by",
+        "updated_by",
+        "deleted_by",
+        "size",
+        "reflection_class",
+        "surface_class",
+        "seasonal_validity_period_start",
+        "seasonal_validity_period_end",
+        "owner",
+        "color",
+        "lifecycle",
+        "road_name",
+        "lane_number",
+        "lane_type",
+        "location_specifier",
+        "source_id",
+        "source_name",
+    )
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -113,12 +157,66 @@ class TrafficSignPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "location",
         "decision_date",
     )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+    )
     ordering = ("-created_at",)
     actions = None
 
 
 @admin.register(TrafficSignReal)
-class TrafficSignRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class TrafficSignRealAdmin(
+    Point3DFieldAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
+):
+    form = TrafficSignRealModelForm
+    fields = (
+        "traffic_sign_plan",
+        ("location", "z_coord"),
+        "height",
+        "direction",
+        "code",
+        "value",
+        "legacy_code",
+        "parent",
+        "order",
+        "txt",
+        "mount_real",
+        "mount_type",
+        "mount_type_fi",
+        "installation_date",
+        "installation_status",
+        "installation_id",
+        "installation_details",
+        "allu_decision_id",
+        "validity_period_start",
+        "validity_period_end",
+        "condition",
+        "affect_area",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "scanned_at",
+        "created_by",
+        "updated_by",
+        "deleted_by",
+        "size",
+        "reflection_class",
+        "surface_class",
+        "seasonal_validity_period_start",
+        "seasonal_validity_period_end",
+        "owner",
+        "manufacturer",
+        "rfid",
+        "color",
+        "lifecycle",
+        "road_name",
+        "lane_number",
+        "lane_type",
+        "location_specifier",
+        "source_id",
+        "source_name",
+    )
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -129,6 +227,10 @@ class TrafficSignRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "lifecycle",
         "location",
         "installation_date",
+    )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
     )
     ordering = ("-created_at",)
     actions = None

--- a/traffic_control/forms.py
+++ b/traffic_control/forms.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.contrib.gis import forms
+from django.contrib.gis.geos import Point
+from django.utils.translation import ugettext_lazy as _
+
+from .models import TrafficSignPlan, TrafficSignReal
+
+
+class Point3DFieldForm(forms.ModelForm):
+    """Form class that allows entering a z coordinate for 3d point"""
+
+    z_coord = forms.FloatField(label=_("Location (z)"))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["location"].label = _("Location (x,y)")
+        if self.instance.location:
+            self.fields["z_coord"].initial = self.instance.location.z
+
+    def clean(self):
+        cleaned_data = super().clean()
+        z_coord = cleaned_data.pop("z_coord")
+        location = cleaned_data["location"]
+        cleaned_data["location"] = Point(
+            location.x, location.y, z_coord, srid=settings.SRID
+        )
+        return cleaned_data
+
+
+class TrafficSignRealModelForm(Point3DFieldForm):
+    class Meta:
+        model = TrafficSignReal
+        fields = "__all__"
+
+
+class TrafficSignPlanModelForm(Point3DFieldForm):
+    class Meta:
+        model = TrafficSignPlan
+        fields = "__all__"

--- a/traffic_control/locale/fi/LC_MESSAGES/django.po
+++ b/traffic_control/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-18 16:26+0200\n"
+"POT-Creation-Date: 2020-03-20 09:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,13 +18,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: traffic_control/admin.py:24
+#: traffic_control/admin.py:26
 msgid "City Infrastructure Platform Administration"
 msgstr "Infraomaisuuden hallinta-alusta"
 
 #: traffic_control/apps.py:7
 msgid "Traffic control"
 msgstr "Liikenteenohjauslaitteet"
+
+#: traffic_control/forms.py:12
+msgid "Location (z)"
+msgstr "Sijainti (z)"
+
+#: traffic_control/forms.py:16
+msgid "Location (x,y)"
+msgstr "Sijainti (x,y)"
 
 #: traffic_control/models/barrier.py:18
 msgid "Closed"

--- a/traffic_control/mixins.py
+++ b/traffic_control/mixins.py
@@ -29,3 +29,19 @@ class SoftDeleteMixin(mixins.DestroyModelMixin):
         instance.deleted_at = make_aware(datetime.now())
         instance.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class Point3DFieldAdminMixin:
+    """A mixin class that shows a map for 3d geometries.
+
+    Django's default behaviour is to use a text field for 3d geometries.
+    The class must be used together with traffic_control.forms.Point3DFieldForm
+    in order to save 3d geometry to model instances
+    """
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        if db_field.name == "location":
+            kwargs["widget"] = self.get_map_widget(db_field)
+            return db_field.formfield(**kwargs)
+
+        return super().formfield_for_dbfield(db_field, request, **kwargs)

--- a/traffic_control/tests/test_admin.py
+++ b/traffic_control/tests/test_admin.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.contrib.admin import AdminSite
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+
+from traffic_control.admin import TrafficSignRealAdmin
+from traffic_control.models import TrafficSignReal
+from traffic_control.models.common import Lifecycle
+from traffic_control.tests.factories import get_user
+
+
+class MockRequest:
+    pass
+
+
+class TrafficSignRealAdminTestCase(TestCase):
+    def setUp(self):
+        self.traffic_sign_real = TrafficSignReal.objects.create(
+            location=Point(10, 10, 5, srid=settings.SRID),
+            direction=0,
+            order=1,
+            created_by=get_user(),
+            updated_by=get_user(),
+            owner="test owner",
+            lifecycle=Lifecycle.ACTIVE,
+        )
+        self.site = AdminSite()
+
+    def test_traffic_sign_real_admin_display_map_widget_for_location(self):
+        ma = TrafficSignRealAdmin(TrafficSignReal, self.site)
+        request = MockRequest()
+        request.user = get_user(admin=True)
+        form = ma.get_form(request, self.traffic_sign_real)
+        self.assertEqual(type(form.base_fields["location"].widget).__name__, "OLMap")
+
+    def test_traffic_sign_admin_has_a_z_coord_field(self):
+        ma = TrafficSignRealAdmin(TrafficSignReal, self.site)
+        request = MockRequest()
+        request.user = get_user(admin=True)
+        form = ma.get_form(request, self.traffic_sign_real)
+        self.assertIn("z_coord", form.base_fields)

--- a/traffic_control/tests/test_forms.py
+++ b/traffic_control/tests/test_forms.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+
+from traffic_control.forms import TrafficSignRealModelForm
+from traffic_control.models import TrafficSignReal
+from traffic_control.models.common import Lifecycle
+from traffic_control.tests.factories import get_user
+
+
+class TrafficSignRealModelFormTestCase(TestCase):
+    def test_update_traffic_sign_real_3d_location(self):
+        user = get_user()
+        data = {
+            "location": Point(5, 5, srid=settings.SRID),
+            "z_coord": 20,
+            "direction": 0,
+            "order": 1,
+            "created_by": user.id,
+            "updated_by": user.id,
+            "owner": "test owner",
+            "lifecycle": Lifecycle.ACTIVE,
+        }
+        user = get_user()
+        traffic_sign_real = TrafficSignReal.objects.create(
+            location=Point(10, 10, 5, srid=settings.SRID),
+            direction=0,
+            order=1,
+            created_by=user,
+            updated_by=user,
+            owner="test owner",
+            lifecycle=Lifecycle.ACTIVE,
+        )
+        form = TrafficSignRealModelForm(data=data, instance=traffic_sign_real)
+        self.assertEqual(form.fields["z_coord"].initial, 5)
+        self.assertTrue(form.is_valid())
+
+        instance = form.save()
+        self.assertEqual(instance.location, Point(5, 5, 20, srid=settings.SRID))
+
+    def test_create_traffic_sign_real_3d_location(self):
+        user = get_user()
+        data = {
+            "location": Point(10, 10, srid=settings.SRID),
+            "z_coord": 20,
+            "direction": 0,
+            "order": 1,
+            "created_by": user.id,
+            "updated_by": user.id,
+            "owner": "test owner",
+            "lifecycle": Lifecycle.ACTIVE,
+        }
+        form = TrafficSignRealModelForm(data=data)
+        form.is_valid()
+        self.assertTrue(form.is_valid())
+        instance = form.save()
+        self.assertEqual(instance.location, Point(10, 10, 20, srid=settings.SRID))


### PR DESCRIPTION
Using a 2d map for xy coordinates editing and a float field for z coordinate editing.
We need to specify the list of fields in order to group the xy coordinate and z
coordinate field together.

Refs: LIIK-77

![admin-3d](https://user-images.githubusercontent.com/1997039/77088497-37b5c580-6a0d-11ea-8777-c777db4f53fb.gif)
