### PR TITLE
Simplify Django compilemessages

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,8 +14,11 @@ if [[ "$COLLECT_STATIC" = "1" ]]; then
     ./manage.py collectstatic --noinput
 fi
 
+# Only translate traffic_control module for now
 echo "Updating translations..."
-./manage.py compilemessages -l fi
+cd traffic_control
+../manage.py compilemessages -l fi
+cd ..
 
 # Start server
 if [[ ! -z "$@" ]]; then


### PR DESCRIPTION
Due to some unknown reason, Django's compilemessages get stuck in the middle of the process in the Azure QA-environment.

In order to narrow down message compilations, compile only the `traffic_control` module (other modules do not need explicit compilations for now).

Refs #LIIK-74