### PR TITLE
Fix admin raising KeyError when z_coord is not filled

### DIFF
--- a/traffic_control/forms.py
+++ b/traffic_control/forms.py
@@ -19,7 +19,7 @@ class Point3DFieldForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        z_coord = cleaned_data.pop("z_coord")
+        z_coord = cleaned_data.pop("z_coord", 0)
         location = cleaned_data["location"]
         cleaned_data["location"] = Point(
             location.x, location.y, z_coord, srid=settings.SRID


### PR DESCRIPTION
The problem was that the z_coord key may not exist when form clean get called.

Refs: LIIK-83