### PR TITLE
Auto save created_by and updated_by when saving objects in Admin UI

### DIFF
--- a/traffic_control/admin.py
+++ b/traffic_control/admin.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 from enumfields.admin import EnumFieldListFilter
 
 from .forms import TrafficSignPlanModelForm, TrafficSignRealModelForm
-from .mixins import Point3DFieldAdminMixin
+from .mixins import Point3DFieldAdminMixin, UserStampedAdminMixin
 from .models import (
     BarrierPlan,
     BarrierPlanFile,
@@ -48,7 +48,7 @@ class BarrierPlanFileInline(admin.TabularInline):
 
 
 @admin.register(BarrierPlan)
-class BarrierPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class BarrierPlanAdmin(UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -59,13 +59,19 @@ class BarrierPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "location",
         "decision_date",
     )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
+    )
     ordering = ("-created_at",)
     actions = None
     inlines = (BarrierPlanFileInline,)
 
 
 @admin.register(BarrierReal)
-class BarrierRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class BarrierRealAdmin(UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -75,6 +81,12 @@ class BarrierRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "lifecycle",
         "location",
         "installation_date",
+    )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
     )
     ordering = ("-created_at",)
     actions = None
@@ -85,7 +97,9 @@ class TrafficLightPlanFileInline(admin.TabularInline):
 
 
 @admin.register(TrafficLightPlan)
-class TrafficLightPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class TrafficLightPlanAdmin(
+    UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
+):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -97,13 +111,21 @@ class TrafficLightPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "location",
         "decision_date",
     )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
+    )
     ordering = ("-created_at",)
     actions = None
     inlines = (TrafficLightPlanFileInline,)
 
 
 @admin.register(TrafficLightReal)
-class TrafficLightRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class TrafficLightRealAdmin(
+    UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
+):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -114,6 +136,12 @@ class TrafficLightRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "lifecycle",
         "location",
         "installation_date",
+    )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
     )
     ordering = ("-created_at",)
     actions = None
@@ -125,7 +153,10 @@ class TrafficSignPlanFileInline(admin.TabularInline):
 
 @admin.register(TrafficSignPlan)
 class TrafficSignPlanAdmin(
-    Point3DFieldAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
+    UserStampedAdminMixin,
+    Point3DFieldAdminMixin,
+    admin.OSMGeoAdmin,
+    AuditLogHistoryAdmin,
 ):
     form = TrafficSignPlanModelForm
     fields = (
@@ -180,6 +211,8 @@ class TrafficSignPlanAdmin(
     readonly_fields = (
         "created_at",
         "updated_at",
+        "created_by",
+        "updated_by",
     )
     ordering = ("-created_at",)
     actions = None
@@ -188,7 +221,10 @@ class TrafficSignPlanAdmin(
 
 @admin.register(TrafficSignReal)
 class TrafficSignRealAdmin(
-    Point3DFieldAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
+    UserStampedAdminMixin,
+    Point3DFieldAdminMixin,
+    admin.OSMGeoAdmin,
+    AuditLogHistoryAdmin,
 ):
     form = TrafficSignRealModelForm
     fields = (
@@ -273,6 +309,8 @@ class TrafficSignRealAdmin(
         "has_additional_signs",
         "created_at",
         "updated_at",
+        "created_by",
+        "updated_by",
     )
     ordering = ("-created_at",)
     actions = None
@@ -319,7 +357,7 @@ class SignpostPlanFileInline(admin.TabularInline):
 
 
 @admin.register(SignpostPlan)
-class SignpostPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class SignpostPlanAdmin(UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -331,13 +369,19 @@ class SignpostPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "location",
         "decision_date",
     )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
+    )
     ordering = ("-created_at",)
     actions = None
     inlines = (SignpostPlanFileInline,)
 
 
 @admin.register(SignpostReal)
-class SignpostRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class SignpostRealAdmin(UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -348,6 +392,12 @@ class SignpostRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "lifecycle",
         "location",
         "installation_date",
+    )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
     )
     ordering = ("-created_at",)
     actions = None
@@ -358,7 +408,7 @@ class MountPlanFileInline(admin.TabularInline):
 
 
 @admin.register(MountPlan)
-class MountPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class MountPlanAdmin(UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -368,13 +418,19 @@ class MountPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "lifecycle",
         "location",
     )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
+    )
     ordering = ("-created_at",)
     actions = None
     inlines = (MountPlanFileInline,)
 
 
 @admin.register(MountReal)
-class MountRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class MountRealAdmin(UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -383,6 +439,12 @@ class MountRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "type",
         "lifecycle",
         "location",
+    )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
     )
     ordering = ("-created_at",)
     actions = None
@@ -393,7 +455,9 @@ class RoadMarkingPlanFileInline(admin.TabularInline):
 
 
 @admin.register(RoadMarkingPlan)
-class RoadMarkingPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class RoadMarkingPlanAdmin(
+    UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
+):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -404,13 +468,21 @@ class RoadMarkingPlanAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "location",
         "decision_date",
     )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
+    )
     ordering = ("-created_at",)
     actions = None
     inlines = (RoadMarkingPlanFileInline,)
 
 
 @admin.register(RoadMarkingReal)
-class RoadMarkingRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
+class RoadMarkingRealAdmin(
+    UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
+):
     default_lon = 2776957.204335059  # Helsinki city coordinates
     default_lat = 8442622.403718097
     default_zoom = 12
@@ -420,6 +492,12 @@ class RoadMarkingRealAdmin(admin.OSMGeoAdmin, AuditLogHistoryAdmin):
         "lifecycle",
         "location",
         "installation_date",
+    )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
     )
     ordering = ("-created_at",)
     actions = None

--- a/traffic_control/mixins.py
+++ b/traffic_control/mixins.py
@@ -45,3 +45,13 @@ class Point3DFieldAdminMixin:
             return db_field.formfield(**kwargs)
 
         return super().formfield_for_dbfield(db_field, request, **kwargs)
+
+
+class UserStampedAdminMixin:
+    """A mixin class for model admin that set created_by/updated_by from request user"""
+
+    def save_model(self, request, obj, form, change):
+        if obj._state.adding:
+            obj.created_by = request.user
+        obj.updated_by = request.user
+        super().save_model(request, obj, form, change)

--- a/traffic_control/tests/test_admin.py
+++ b/traffic_control/tests/test_admin.py
@@ -16,6 +16,7 @@ class MockRequest:
 class TrafficSignRealAdminTestCase(TestCase):
     def setUp(self):
         self.user = get_user()
+        self.admin = get_user(admin=True)
         self.traffic_sign_real = TrafficSignReal.objects.create(
             location=Point(10, 10, 5, srid=settings.SRID),
             legacy_code="100",
@@ -31,14 +32,14 @@ class TrafficSignRealAdminTestCase(TestCase):
     def test_traffic_sign_real_admin_display_map_widget_for_location(self):
         ma = TrafficSignRealAdmin(TrafficSignReal, self.site)
         request = MockRequest()
-        request.user = get_user(admin=True)
+        request.user = self.admin
         form = ma.get_form(request, self.traffic_sign_real)
         self.assertEqual(type(form.base_fields["location"].widget).__name__, "OLMap")
 
     def test_traffic_sign_admin_has_a_z_coord_field(self):
         ma = TrafficSignRealAdmin(TrafficSignReal, self.site)
         request = MockRequest()
-        request.user = get_user(admin=True)
+        request.user = self.admin
         form = ma.get_form(request, self.traffic_sign_real)
         self.assertIn("z_coord", form.base_fields)
 
@@ -59,3 +60,26 @@ class TrafficSignRealAdminTestCase(TestCase):
     def test_has_additional_signs_return_no(self):
         ma = TrafficSignRealAdmin(TrafficSignReal, self.site)
         self.assertEqual(ma.has_additional_signs(self.traffic_sign_real), "Ei")
+
+    def test_save_model_set_created_by_and_updated_by_for_creating(self):
+        ma = TrafficSignRealAdmin(TrafficSignReal, self.site)
+        request = MockRequest()
+        request.user = self.admin
+        traffic_sign_real = TrafficSignReal(
+            location=Point(1, 1, 5, srid=settings.SRID),
+            legacy_code="100",
+            direction=0,
+            order=1,
+            owner="test owner",
+        )
+        ma.save_model(request, traffic_sign_real, None, None)
+        self.assertEqual(traffic_sign_real.created_by, self.admin)
+        self.assertEqual(traffic_sign_real.updated_by, self.admin)
+
+    def test_save_model_set_updated_by_for_updating(self):
+        ma = TrafficSignRealAdmin(TrafficSignReal, self.site)
+        request = MockRequest()
+        request.user = self.admin
+        ma.save_model(request, self.traffic_sign_real, None, None)
+        self.assertEqual(self.traffic_sign_real.created_by, self.user)
+        self.assertEqual(self.traffic_sign_real.updated_by, self.admin)


### PR DESCRIPTION
Mark these fields as readonly in Admin UI and auto save the logged in user to the fields.

Refs: LIIK-84

![save-created-by-updated-by](https://user-images.githubusercontent.com/1997039/77761439-b8de0f80-7040-11ea-89ff-8890b22dad74.gif)
