### PR TITLE
Enable bulk soft delete in Admin UI

### DIFF
--- a/traffic_control/admin.py
+++ b/traffic_control/admin.py
@@ -68,7 +68,6 @@ class BarrierPlanAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
     inlines = (BarrierPlanFileInline,)
 
 
@@ -93,7 +92,6 @@ class BarrierRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
 
 
 class TrafficLightPlanFileInline(admin.TabularInline):
@@ -122,7 +120,6 @@ class TrafficLightPlanAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
     inlines = (TrafficLightPlanFileInline,)
 
 
@@ -148,7 +145,6 @@ class TrafficLightRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
 
 
 class TrafficSignPlanFileInline(admin.TabularInline):
@@ -220,7 +216,6 @@ class TrafficSignPlanAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
     inlines = (TrafficSignPlanFileInline,)
 
 
@@ -321,7 +316,6 @@ class TrafficSignRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
     list_filter = [
         ("lifecycle", EnumFieldListFilter),
         ("installation_status", EnumFieldListFilter),
@@ -386,7 +380,6 @@ class SignpostPlanAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
     inlines = (SignpostPlanFileInline,)
 
 
@@ -412,7 +405,6 @@ class SignpostRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
 
 
 class MountPlanFileInline(admin.TabularInline):
@@ -439,7 +431,6 @@ class MountPlanAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
     inlines = (MountPlanFileInline,)
 
 
@@ -463,7 +454,6 @@ class MountRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
 
 
 class RoadMarkingPlanFileInline(admin.TabularInline):
@@ -491,7 +481,6 @@ class RoadMarkingPlanAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
     inlines = (RoadMarkingPlanFileInline,)
 
 
@@ -516,7 +505,6 @@ class RoadMarkingRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    actions = None
 
 
 @admin.register(TrafficSignCode)

--- a/traffic_control/mixins/admin.py
+++ b/traffic_control/mixins/admin.py
@@ -1,6 +1,3 @@
-from django.utils import timezone
-
-
 class Point3DFieldAdminMixin:
     """A mixin class that shows a map for 3d geometries.
 
@@ -33,7 +30,4 @@ class SoftDeleteAdminMixin:
         return qs.active()
 
     def delete_model(self, request, obj):
-        obj.is_active = False
-        obj.deleted_at = timezone.now()
-        obj.deleted_by = request.user
-        obj.save()
+        obj.soft_delete(request.user)

--- a/traffic_control/mixins/admin.py
+++ b/traffic_control/mixins/admin.py
@@ -31,3 +31,11 @@ class SoftDeleteAdminMixin:
 
     def delete_model(self, request, obj):
         obj.soft_delete(request.user)
+
+    def delete_queryset(self, request, queryset):
+        # audit log entries are created via saving signals,
+        # using bulk operations will not trigger the signals
+        # and will skip the auditing. Thus soft delete
+        # objects in queryset one by one.
+        for obj in queryset:
+            obj.soft_delete(request.user)

--- a/traffic_control/mixins/api.py
+++ b/traffic_control/mixins/api.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-
-from django.utils.timezone import make_aware
 from rest_framework import mixins, status
 from rest_framework.response import Response
 
@@ -24,8 +21,5 @@ class SoftDeleteMixin(mixins.DestroyModelMixin):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        instance.is_active = False
-        instance.deleted_by = request.user
-        instance.deleted_at = make_aware(datetime.now())
-        instance.save()
+        instance.soft_delete(request.user)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/traffic_control/mixins/models.py
+++ b/traffic_control/mixins/models.py
@@ -1,0 +1,9 @@
+from django.utils import timezone
+
+
+class SoftDeleteModelMixin:
+    def soft_delete(self, user):
+        self.is_active = False
+        self.deleted_at = timezone.now()
+        self.deleted_by = user
+        self.save()

--- a/traffic_control/models/barrier.py
+++ b/traffic_control/models/barrier.py
@@ -7,6 +7,7 @@ from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _  # NOQA
 from enumfields import Enum, EnumField, EnumIntegerField
 
+from ..mixins.models import SoftDeleteModelMixin
 from .common import Condition, InstallationStatus, Lifecycle, TrafficSignCode
 from .utils import SoftDeleteQuerySet
 
@@ -55,7 +56,7 @@ class LocationSpecifier(Enum):
         LEFT = _("Left of road or lane")
 
 
-class BarrierPlan(models.Model):
+class BarrierPlan(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )
@@ -160,7 +161,7 @@ class BarrierPlanFile(models.Model):
         return "%s" % self.file
 
 
-class BarrierReal(models.Model):
+class BarrierReal(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )

--- a/traffic_control/models/mount.py
+++ b/traffic_control/models/mount.py
@@ -7,6 +7,7 @@ from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _  # NOQA
 from enumfields import Enum, EnumField, EnumIntegerField
 
+from ..mixins.models import SoftDeleteModelMixin
 from .common import Condition, InstallationStatus, Lifecycle
 from .utils import SoftDeleteQuerySet
 
@@ -52,7 +53,7 @@ class PortalType(models.Model):
         return "%s - %s - %s" % (self.structure, self.build_type, self.model)
 
 
-class MountPlan(models.Model):
+class MountPlan(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )
@@ -149,7 +150,7 @@ class MountPlanFile(models.Model):
         return "%s" % self.file
 
 
-class MountReal(models.Model):
+class MountReal(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )

--- a/traffic_control/models/road_marking.py
+++ b/traffic_control/models/road_marking.py
@@ -7,6 +7,7 @@ from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _  # NOQA
 from enumfields import Enum, EnumField, EnumIntegerField
 
+from ..mixins.models import SoftDeleteModelMixin
 from .common import Condition, InstallationStatus, Lifecycle, TrafficSignCode
 from .traffic_sign import TrafficSignPlan, TrafficSignReal
 from .utils import SoftDeleteQuerySet
@@ -62,7 +63,7 @@ class LocationSpecifier(Enum):
         LEFT_SIDE_OF_LANE_OR_ROAD = _("Left side of lane or road")
 
 
-class RoadMarkingPlan(models.Model):
+class RoadMarkingPlan(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )
@@ -201,7 +202,7 @@ class RoadMarkingPlanFile(models.Model):
         return "%s" % self.file
 
 
-class RoadMarkingReal(models.Model):
+class RoadMarkingReal(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )

--- a/traffic_control/models/signpost.py
+++ b/traffic_control/models/signpost.py
@@ -7,6 +7,7 @@ from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _  # NOQA
 from enumfields import Enum, EnumField, EnumIntegerField
 
+from ..mixins.models import SoftDeleteModelMixin
 from .common import (
     Condition,
     InstallationStatus,
@@ -34,7 +35,7 @@ class LocationSpecifier(Enum):
         VERTICAL = _("Vertical")
 
 
-class SignpostPlan(models.Model):
+class SignpostPlan(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )
@@ -186,7 +187,7 @@ class SignpostPlanFile(models.Model):
         return "%s" % self.file
 
 
-class SignpostReal(models.Model):
+class SignpostReal(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )

--- a/traffic_control/models/traffic_light.py
+++ b/traffic_control/models/traffic_light.py
@@ -7,6 +7,7 @@ from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _  # NOQA
 from enumfields import Enum, EnumField, EnumIntegerField
 
+from ..mixins.models import SoftDeleteModelMixin
 from .common import Condition, InstallationStatus, Lifecycle, TrafficSignCode
 from .mount import MountPlan, MountReal, MountType
 from .utils import SoftDeleteQuerySet
@@ -45,7 +46,7 @@ class TrafficLightType(Enum):
         BUTTON = _("Button")
 
 
-class TrafficLightPlan(models.Model):
+class TrafficLightPlan(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )
@@ -160,7 +161,7 @@ class TrafficLightPlanFile(models.Model):
         return "%s" % self.file
 
 
-class TrafficLightReal(models.Model):
+class TrafficLightReal(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )

--- a/traffic_control/models/traffic_sign.py
+++ b/traffic_control/models/traffic_sign.py
@@ -7,6 +7,7 @@ from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _  # NOQA
 from enumfields import Enum, EnumField, EnumIntegerField
 
+from ..mixins.models import SoftDeleteModelMixin
 from .common import (
     Color,
     Condition,
@@ -38,7 +39,7 @@ class LocationSpecifier(Enum):
         OUTSIDE = _("Outside")
 
 
-class TrafficSignPlan(models.Model):
+class TrafficSignPlan(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )
@@ -192,7 +193,7 @@ class TrafficSignPlanFile(models.Model):
         return "%s" % self.file
 
 
-class TrafficSignReal(models.Model):
+class TrafficSignReal(SoftDeleteModelMixin, models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )

--- a/traffic_control/models/utils.py
+++ b/traffic_control/models/utils.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils import timezone
 
 
 class SoftDeleteQuerySet(models.QuerySet):
@@ -10,6 +9,3 @@ class SoftDeleteQuerySet(models.QuerySet):
 
     def deleted(self):
         return self.filter(is_active=False)
-
-    def soft_delete(self, user):
-        self.update(is_active=False, deleted_at=timezone.now(), deleted_by=user)

--- a/traffic_control/tests/test_admin.py
+++ b/traffic_control/tests/test_admin.py
@@ -102,3 +102,12 @@ class TrafficSignRealAdminTestCase(TestCase):
         ma.delete_model(request, self.traffic_sign_real)
         qs = ma.get_queryset(request)
         self.assertEqual(qs.count(), 0)
+
+    def test_delete_queryset_soft_delete_objects_in_queryset(self):
+        ma = TrafficSignRealAdmin(TrafficSignReal, self.site)
+        request = MockRequest()
+        request.user = self.admin
+        ma.delete_model(request, self.traffic_sign_real)
+        ma.delete_queryset(request, TrafficSignReal.objects.all())
+        self.traffic_sign_real.refresh_from_db()
+        self.assertFalse(self.traffic_sign_real.is_active)


### PR DESCRIPTION
This PR implements the bulk soft delete for soft delete enabled model admins. The audit log relies on signals to create log entries, and thus we cannot use the bulk operations on queryset to do the soft delete because the bulk operation does not trigger the signals. So we have to soft delete objects in queryset one by one in order to trigger the signals and create audit logs.

Note that since we are doing soft delete, the action appeared in log entry is an "update" action instead of a "delete" action.

Refs: LIIK-85