### PR TITLE
Soft delete main traffic sign also soft delete associated additional signs

### DIFF
--- a/traffic_control/models/traffic_sign.py
+++ b/traffic_control/models/traffic_sign.py
@@ -352,7 +352,7 @@ class TrafficSignReal(SoftDeleteModelMixin, models.Model):
         super().save(*args, **kwargs)
 
     def has_additional_signs(self):
-        return self.children.all().exists()
+        return self.children.active().exists()
 
 
 auditlog.register(TrafficSignPlan)

--- a/traffic_control/models/traffic_sign.py
+++ b/traffic_control/models/traffic_sign.py
@@ -4,6 +4,7 @@ from auditlog.registry import auditlog
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.gis.db import models
+from django.db import transaction
 from django.utils.translation import ugettext_lazy as _  # NOQA
 from enumfields import Enum, EnumField, EnumIntegerField
 
@@ -353,6 +354,12 @@ class TrafficSignReal(SoftDeleteModelMixin, models.Model):
 
     def has_additional_signs(self):
         return self.children.active().exists()
+
+    @transaction.atomic
+    def soft_delete(self, user):
+        super().soft_delete(user)
+        for additional_sign in self.children.active():
+            additional_sign.soft_delete(user)
 
 
 auditlog.register(TrafficSignPlan)

--- a/traffic_control/tests/models/test_traffic_sign.py
+++ b/traffic_control/tests/models/test_traffic_sign.py
@@ -49,3 +49,19 @@ class TrafficSignRealTestCase(TestCase):
             owner="test owner",
         )
         self.assertFalse(self.main_sign.has_additional_signs())
+
+    def test_soft_delete_main_traffic_sign_also_soft_delete_additional_sign(self):
+        additional_sign = TrafficSignReal.objects.create(
+            parent=self.main_sign,
+            location=Point(1, 1, 5, srid=settings.SRID),
+            legacy_code="800",
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        self.main_sign.soft_delete(self.user)
+        additional_sign.refresh_from_db()
+        self.assertFalse(additional_sign.is_active)
+        self.assertEqual(additional_sign.deleted_by, self.user)

--- a/traffic_control/tests/models/test_traffic_sign.py
+++ b/traffic_control/tests/models/test_traffic_sign.py
@@ -34,3 +34,18 @@ class TrafficSignRealTestCase(TestCase):
             owner="test owner",
         )
         self.assertTrue(self.main_sign.has_additional_signs())
+
+    def test_has_additional_signs_return_false_with_soft_deleted_additional_sign(self):
+        TrafficSignReal.objects.create(
+            parent=self.main_sign,
+            location=Point(1, 1, 5, srid=settings.SRID),
+            legacy_code="800",
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            is_active=False,
+            deleted_by=self.user,
+            owner="test owner",
+        )
+        self.assertFalse(self.main_sign.has_additional_signs())


### PR DESCRIPTION
The bulk delete action in Admin UI is changed to use the soft_delete model method. See details: https://github.com/City-of-Helsinki/city-infrastructure-platform/pull/56

Refs: LIIK-95