### PR TITLE
Use 0.0 as Z-value in Vaisala data import

### DIFF
--- a/traffic_control/utils/send_traffic_sign_reals_vaisala.py
+++ b/traffic_control/utils/send_traffic_sign_reals_vaisala.py
@@ -64,9 +64,7 @@ with open(filename, mode="r", encoding="utf-8-sig") as csv_file:
     for row in csv_reader:
         point = ogr.Geometry(ogr.wkbPoint)
         point.AddPoint(
-            float(row["longitude"].strip()),
-            float(row["latitude"].strip()),
-            float(row["elevation"].strip()),
+            float(row["longitude"].strip()), float(row["latitude"].strip()), 0.0
         )
         point.Transform(transform)
         try:


### PR DESCRIPTION
This PR changes Vaisala traffic signs import to use 0.0 as Z-value for all data.
Refs #LIIK-92