### PR TITLE
Add ordered traffic signs to MountReal Admin UI and REST API

### DIFF
--- a/traffic_control/admin.py
+++ b/traffic_control/admin.py
@@ -29,6 +29,7 @@ from .models import (
     TrafficSignPlanFile,
     TrafficSignReal,
 )
+from .models.utils import order_queryset_by_z_coord_desc
 
 admin.site.site_header = _("City Infrastructure Platform Administration")
 
@@ -449,6 +450,28 @@ class MountPlanAdmin(
     inlines = (MountPlanFileInline,)
 
 
+class OrderedTrafficSignRealInline(admin.TabularInline):
+    model = TrafficSignReal
+    fields = ("id", "parent", "z_coord")
+    readonly_fields = ("id", "parent", "z_coord")
+    show_change_link = True
+    can_delete = False
+    verbose_name = _("Ordered traffic sign")
+    verbose_name_plural = _("Ordered traffic signs")
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return order_queryset_by_z_coord_desc(qs)
+
+    def z_coord(self, obj):
+        return obj.location.z
+
+    z_coord.short_description = _("location (z)")
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
 @admin.register(MountReal)
 class MountRealAdmin(
     SoftDeleteAdminMixin, UserStampedAdminMixin, admin.OSMGeoAdmin, AuditLogHistoryAdmin
@@ -469,6 +492,7 @@ class MountRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
+    inlines = (OrderedTrafficSignRealInline,)
 
 
 class RoadMarkingPlanFileInline(admin.TabularInline):

--- a/traffic_control/models/mount.py
+++ b/traffic_control/models/mount.py
@@ -9,7 +9,7 @@ from enumfields import Enum, EnumField, EnumIntegerField
 
 from ..mixins.models import SoftDeleteModelMixin
 from .common import Condition, InstallationStatus, Lifecycle
-from .utils import SoftDeleteQuerySet
+from .utils import order_queryset_by_z_coord_desc, SoftDeleteQuerySet
 
 
 class MountType(Enum):
@@ -248,6 +248,12 @@ class MountReal(SoftDeleteModelMixin, models.Model):
 
     def __str__(self):
         return "%s %s" % (self.id, self.type)
+
+    @property
+    def ordered_traffic_signs(self):
+        """traffic sign reals ordered by z coordinate from top down"""
+        qs = self.trafficsignreal_set.active()
+        return order_queryset_by_z_coord_desc(qs)
 
 
 auditlog.register(MountPlan)

--- a/traffic_control/models/utils.py
+++ b/traffic_control/models/utils.py
@@ -9,3 +9,13 @@ class SoftDeleteQuerySet(models.QuerySet):
 
     def deleted(self):
         return self.filter(is_active=False)
+
+
+def order_queryset_by_z_coord_desc(queryset, geometry_field="location"):
+    """Order an queryset based on point geometry's z coordinate"""
+    return queryset.annotate(
+        z_coord=models.ExpressionWrapper(
+            models.Func(geometry_field, function="ST_Z"),
+            output_field=models.FloatField(),
+        )
+    ).order_by("-z_coord")

--- a/traffic_control/serializers.py
+++ b/traffic_control/serializers.py
@@ -190,6 +190,10 @@ class MountPlanGeoJSONSerializer(MountPlanSerializer):
 
 
 class MountRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+    ordered_traffic_signs = serializers.PrimaryKeyRelatedField(
+        read_only=True, many=True
+    )
+
     class Meta:
         model = MountReal
         fields = "__all__"

--- a/traffic_control/tests/models/test_mount.py
+++ b/traffic_control/tests/models/test_mount.py
@@ -1,0 +1,58 @@
+from django.conf import settings
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+
+from traffic_control.models import MountReal, MountType, TrafficSignReal
+from traffic_control.tests.factories import get_user
+
+
+class MountRealTestCase(TestCase):
+    def setUp(self):
+        self.user = get_user()
+        self.mount_real = MountReal.objects.create(
+            location=Point(1, 1, srid=settings.SRID),
+            type=MountType.LIGHTPOLE,
+            owner="test owner",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+    def test_ordered_traffic_signs_property_return_ordered_traffic_signs(self):
+        traffic_sign_1 = TrafficSignReal.objects.create(
+            location=Point(0, 0, 2, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Lightpole",
+            mount_real=self.mount_real,
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        traffic_sign_2 = TrafficSignReal.objects.create(
+            location=Point(0, 0, 2.5, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Lightpole",
+            mount_real=self.mount_real,
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        traffic_sign_3 = TrafficSignReal.objects.create(
+            location=Point(0, 0, 1.8, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Lightpole",
+            mount_real=self.mount_real,
+            parent=traffic_sign_1,
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        self.assertQuerysetEqual(
+            self.mount_real.ordered_traffic_signs,
+            [repr(traffic_sign_2), repr(traffic_sign_1), repr(traffic_sign_3)],
+        )


### PR DESCRIPTION
This PR added an ordered list of traffic signs to both MountReal Admin UI and API end point. The traffic sign real objects mounted to the same mount real object are ordered by z coordinates in a descending order.

Refs: LIIK-73

![image](https://user-images.githubusercontent.com/1997039/78342893-af095e80-75a2-11ea-844d-e3ac7847c907.png)
