### PR TITLE
Use same mount real objects for nearby traffic signs with same mount type

### DIFF
--- a/traffic_control/management/commands/generate_mount_real_objects.py
+++ b/traffic_control/management/commands/generate_mount_real_objects.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.gis.geos import Point
+from django.contrib.gis.measure import D
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
@@ -11,38 +12,64 @@ OWNER = "Helsingin kaupunki"
 class Command(BaseCommand):
     help = "Generate mount real objects from traffic sign real objects"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-r",
+            "--radius",
+            type=float,
+            default=1,
+            help="Search radius for existing mount real",
+        )
+
     def handle(self, *args, **options):
         self.stdout.write("Generating mount real objects ...")
-        count = 0
         # main traffic signs are those whose legacy code
         # does not start with 8
-        main_traffic_signs = TrafficSignReal.objects.filter(
-            mount_real__isnull=True, mount_type__isnull=False
-        ).exclude(legacy_code__startswith="8")
+        main_traffic_signs = (
+            TrafficSignReal.objects.active()
+            .filter(mount_real__isnull=True, mount_type__isnull=False)
+            .exclude(legacy_code__startswith="8")
+        )
+
         for main_traffic_sign in main_traffic_signs:
             # wrapper MountReal object creation and traffic sign
             # linking in a transaction so that unlinked main traffic
             # signs and linked additional traffic signs can still be
             # found in a second run on failures
             with transaction.atomic():
-                mount_real = MountReal.objects.create(
-                    location=Point(
-                        main_traffic_sign.location.x,
-                        main_traffic_sign.location.y,
-                        srid=settings.SRID,
-                    ),
-                    type=MountType[main_traffic_sign.mount_type.upper()].value,
-                    owner=OWNER,
-                    created_by=main_traffic_sign.created_by,
-                    updated_by=main_traffic_sign.updated_by,
-                )
+                mount_real = self.get_mount_real(main_traffic_sign, options["radius"])
                 main_traffic_sign.mount_real = mount_real
                 main_traffic_sign.save(update_fields=("mount_real",))
-                main_traffic_sign.children.all().update(mount_real=mount_real)
-            count += 1
+                main_traffic_sign.children.active().update(mount_real=mount_real)
 
-        self.stdout.write(
-            "Generating mount real objects completed. {0} mount real objects created.".format(
-                count
+        self.stdout.write("Generating mount real objects completed.")
+
+    def get_mount_real(self, traffic_sign, radius):
+        """Get mount real object for traffic sign
+
+        Return the mount real if there exists one with the same
+        mount type within given radius, otherwise create new
+        mount real object using the same location (x, y) as the
+        traffic sign
+        """
+        mount_type = MountType[traffic_sign.mount_type.upper()].value
+        mount_real = (
+            MountReal.objects.active()
+            .filter(
+                location__dwithin=(traffic_sign.location, D(m=radius)), type=mount_type,
             )
+            .first()
         )
+        if not mount_real:
+            mount_real = MountReal.objects.create(
+                location=Point(
+                    traffic_sign.location.x,
+                    traffic_sign.location.y,
+                    srid=settings.SRID,
+                ),
+                type=mount_type,
+                owner=OWNER,
+                created_by=traffic_sign.created_by,
+                updated_by=traffic_sign.updated_by,
+            )
+        return mount_real

--- a/traffic_control/tests/management/commands/test_generate_mount_real_objects.py
+++ b/traffic_control/tests/management/commands/test_generate_mount_real_objects.py
@@ -40,3 +40,80 @@ class GenerateMountRealObjectsTestCase(TestCase):
         mount_real = MountReal.objects.first()
         self.assertEqual(main_sign.mount_real, mount_real)
         self.assertEqual(additional_sign.mount_real, mount_real)
+
+    def test_create_a_single_mount_real_for_nearby_traffic_signs(self):
+        main_sign_1 = TrafficSignReal.objects.create(
+            location=Point(1, 1, 10, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Lightpole",
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        main_sign_2 = TrafficSignReal.objects.create(
+            location=Point(1, 0.8, 5, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Lightpole",
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        call_command("generate_mount_real_objects")
+        self.assertEqual(MountReal.objects.count(), 1)
+        mount_real = MountReal.objects.first()
+        main_sign_1.refresh_from_db()
+        main_sign_2.refresh_from_db()
+        self.assertEqual(main_sign_1.mount_real, mount_real)
+        self.assertEqual(main_sign_2.mount_real, mount_real)
+
+    def test_create_separate_mount_reals_for_further_away_traffic_signs(self):
+        TrafficSignReal.objects.create(
+            location=Point(1, 1, 10, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Lightpole",
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        TrafficSignReal.objects.create(
+            location=Point(2, 2, 5, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Lightpole",
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        call_command("generate_mount_real_objects")
+        self.assertEqual(MountReal.objects.count(), 2)
+
+    def test_create_separate_mount_reals_for_different_mount_type_traffic_signs(self):
+        TrafficSignReal.objects.create(
+            location=Point(1, 1, 10, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Lightpole",
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        TrafficSignReal.objects.create(
+            location=Point(1, 0.8, 5, srid=settings.SRID),
+            legacy_code="100",
+            mount_type="Pole",
+            direction=0,
+            order=1,
+            created_by=self.user,
+            updated_by=self.user,
+            owner="test owner",
+        )
+        call_command("generate_mount_real_objects")
+        self.assertEqual(MountReal.objects.count(), 2)


### PR DESCRIPTION
Nearby main traffic signs with same mount type  are likely to
have the same mount object. This commit enhances the generate_mount_real_objects
management command with the logic to re-use existing nearby mount real objects
when creating mount real for traffic sign real objects.

Refs: LIIK-97