### PR TITLE
Namespace and URL version the API

### DIFF
--- a/city-infrastructure-platform/urls.py
+++ b/city-infrastructure-platform/urls.py
@@ -85,7 +85,7 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path("ha/", include("helusers.urls", namespace="helusers")),
-    path("api/", include((router.urls, "api"), namespace="api")),
+    path("v1/", include((router.urls, "traffic_control"), namespace="v1")),
     path("auth/", include("social_django.urls", namespace="social")),
     url(
         r"^swagger(?P<format>\.json|\.yaml)$",

--- a/traffic_control/tests/test_api_file_upload.py
+++ b/traffic_control/tests/test_api_file_upload.py
@@ -221,8 +221,7 @@ def test_file_rewrite(factory, model_class, file_model_class, related_name, url_
 
     patch_response = api_client.patch(
         reverse(
-            f"v1:{url_name}-change-file",
-            kwargs={"pk": obj.id, "file_pk": file_obj.id},
+            f"v1:{url_name}-change-file", kwargs={"pk": obj.id, "file_pk": file_obj.id},
         ),
         data={"file": io.BytesIO(b"Rewritten file contents")},
         format="multipart",
@@ -316,8 +315,7 @@ def test_file_delete(factory, model_class, file_model_class, related_name, url_n
 
     delete_response = api_client.delete(
         reverse(
-            f"v1:{url_name}-change-file",
-            kwargs={"pk": obj.id, "file_pk": file_obj.id},
+            f"v1:{url_name}-change-file", kwargs={"pk": obj.id, "file_pk": file_obj.id},
         ),
     )
 

--- a/traffic_control/tests/test_api_file_upload.py
+++ b/traffic_control/tests/test_api_file_upload.py
@@ -89,7 +89,7 @@ def test_file_upload(factory, model_class, url_name):
     obj = factory()
 
     post_response = api_client.post(
-        reverse(f"api:{url_name}-post-files", kwargs={"pk": obj.pk}),
+        reverse(f"v1:{url_name}-post-files", kwargs={"pk": obj.pk}),
         data={
             "file1": io.BytesIO(b"File 1 contents"),
             "file2": io.BytesIO(b"File 2 contents"),
@@ -131,7 +131,7 @@ def test_invalid_file_upload(factory, model_class, url_name):
     obj = factory()
 
     post_response = api_client.post(
-        reverse(f"api:{url_name}-post-files", kwargs={"pk": obj.pk}),
+        reverse(f"v1:{url_name}-post-files", kwargs={"pk": obj.pk}),
         data={"file1": io.BytesIO(b"File contents"), "file2": "This is not a file"},
         format="multipart",
     )
@@ -221,7 +221,7 @@ def test_file_rewrite(factory, model_class, file_model_class, related_name, url_
 
     patch_response = api_client.patch(
         reverse(
-            f"api:{url_name}-change-file",
+            f"v1:{url_name}-change-file",
             kwargs={"pk": obj.id, "file_pk": file_obj.id},
         ),
         data={"file": io.BytesIO(b"Rewritten file contents")},
@@ -316,7 +316,7 @@ def test_file_delete(factory, model_class, file_model_class, related_name, url_n
 
     delete_response = api_client.delete(
         reverse(
-            f"api:{url_name}-change-file",
+            f"v1:{url_name}-change-file",
             kwargs={"pk": obj.id, "file_pk": file_obj.id},
         ),
     )

--- a/traffic_control/tests/test_barrier_api.py
+++ b/traffic_control/tests/test_barrier_api.py
@@ -135,9 +135,7 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
             "road_name": "Test street 1",
         }
-        response = self.client.post(
-            reverse("v1:barrierplan-list"), data, format="json"
-        )
+        response = self.client.post(reverse("v1:barrierplan-list"), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(BarrierPlan.objects.count(), 1)
         self.assertEqual(response.data.get("location"), data["location"])
@@ -338,9 +336,7 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
             "road_name": "Test street 1",
         }
-        response = self.client.post(
-            reverse("v1:barrierreal-list"), data, format="json"
-        )
+        response = self.client.post(reverse("v1:barrierreal-list"), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(BarrierReal.objects.count(), 1)
         self.assertEqual(response.data.get("location"), data["location"])

--- a/traffic_control/tests/test_barrier_api.py
+++ b/traffic_control/tests/test_barrier_api.py
@@ -30,7 +30,7 @@ def test_filter_barrier_plans_location(location, location_query, expected):
 
     barrier_plan = get_barrier_plan(location)
     response = api_client.get(
-        reverse("api:barrierplan-list"), {"location": location_query.ewkt}
+        reverse("v1:barrierplan-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -53,7 +53,7 @@ def test_filter_error_barrier_plans_location(location, location_query, expected)
 
     get_barrier_plan(location)
     response = api_client.get(
-        reverse("api:barrierplan-list"), {"location": location_query}
+        reverse("v1:barrierplan-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -68,7 +68,7 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_barrier_plan()
-        response = self.client.get(reverse("api:barrierplan-list"))
+        response = self.client.get(reverse("v1:barrierplan-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -85,7 +85,7 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_barrier_plan()
         response = self.client.get(
-            reverse("api:barrierplan-list"), data={"geo_format": "geojson"}
+            reverse("v1:barrierplan-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -103,7 +103,7 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
         """
         barrier_plan = self.__create_test_barrier_plan()
         response = self.client.get(
-            reverse("api:barrierplan-detail", kwargs={"pk": barrier_plan.id})
+            reverse("v1:barrierplan-detail", kwargs={"pk": barrier_plan.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(barrier_plan.id))
@@ -115,7 +115,7 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
         """
         barrier_plan = self.__create_test_barrier_plan()
         response = self.client.get(
-            reverse("api:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
+            reverse("v1:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -136,7 +136,7 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
             "road_name": "Test street 1",
         }
         response = self.client.post(
-            reverse("api:barrierplan-list"), data, format="json"
+            reverse("v1:barrierplan-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(BarrierPlan.objects.count(), 1)
@@ -163,7 +163,7 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
             "road_name": "Test street 1",
         }
         response = self.client.put(
-            reverse("api:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
+            reverse("v1:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
             data,
             format="json",
         )
@@ -183,7 +183,7 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
         """
         barrier_plan = self.__create_test_barrier_plan()
         response = self.client.delete(
-            reverse("api:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
+            reverse("v1:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(BarrierPlan.objects.count(), 1)
@@ -196,11 +196,11 @@ class BarrierPlanTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_barrier_plan_returns_not_found(self):
         barrier_plan = self.__create_test_barrier_plan()
         response = self.client.delete(
-            reverse("api:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
+            reverse("v1:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
+            reverse("v1:barrierplan-detail", kwargs={"pk": barrier_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -232,7 +232,7 @@ def test_filter_barrier_reals_location(location, location_query, expected):
 
     barrier_real = get_barrier_real(location)
     response = api_client.get(
-        reverse("api:barrierreal-list"), {"location": location_query.ewkt}
+        reverse("v1:barrierreal-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -256,7 +256,7 @@ def test_filter_error_barrier_reals_location(location, location_query, expected)
 
     get_barrier_plan(location)
     response = api_client.get(
-        reverse("api:barrierreal-list"), {"location": location_query}
+        reverse("v1:barrierreal-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -271,7 +271,7 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_barrier_real()
-        response = self.client.get(reverse("api:barrierreal-list"))
+        response = self.client.get(reverse("v1:barrierreal-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -288,7 +288,7 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_barrier_real()
         response = self.client.get(
-            reverse("api:barrierreal-list"), data={"geo_format": "geojson"}
+            reverse("v1:barrierreal-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -306,7 +306,7 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
         """
         barrier_real = self.__create_test_barrier_real()
         response = self.client.get(
-            reverse("api:barrierreal-detail", kwargs={"pk": barrier_real.id})
+            reverse("v1:barrierreal-detail", kwargs={"pk": barrier_real.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(barrier_real.id))
@@ -318,7 +318,7 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
         """
         barrier_real = self.__create_test_barrier_real()
         response = self.client.get(
-            reverse("api:barrierreal-detail", kwargs={"pk": barrier_real.id}),
+            reverse("v1:barrierreal-detail", kwargs={"pk": barrier_real.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -339,7 +339,7 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
             "road_name": "Test street 1",
         }
         response = self.client.post(
-            reverse("api:barrierreal-list"), data, format="json"
+            reverse("v1:barrierreal-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(BarrierReal.objects.count(), 1)
@@ -367,7 +367,7 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
             "road_name": "Test street 1",
         }
         response = self.client.put(
-            reverse("api:barrierreal-detail", kwargs={"pk": barrier_real.id}),
+            reverse("v1:barrierreal-detail", kwargs={"pk": barrier_real.id}),
             data,
             format="json",
         )
@@ -388,7 +388,7 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
         """
         barrier_real = self.__create_test_barrier_real()
         response = self.client.delete(
-            reverse("api:barrierreal-detail", kwargs={"pk": barrier_real.id}),
+            reverse("v1:barrierreal-detail", kwargs={"pk": barrier_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(BarrierPlan.objects.count(), 1)
@@ -401,11 +401,11 @@ class BarrierRealTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_barrier_real_returns_not_found(self):
         barrier_real = self.__create_test_barrier_real()
         response = self.client.delete(
-            reverse("api:barrierreal-detail", kwargs={"pk": barrier_real.id}),
+            reverse("v1:barrierreal-detail", kwargs={"pk": barrier_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:barrierreal-detail", kwargs={"pk": barrier_real.id}),
+            reverse("v1:barrierreal-detail", kwargs={"pk": barrier_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/traffic_control/tests/test_mount_api.py
+++ b/traffic_control/tests/test_mount_api.py
@@ -30,7 +30,7 @@ def test_filter_mount_plans_location(location, location_query, expected):
 
     mount_plan = get_mount_plan(location)
     response = api_client.get(
-        reverse("api:mountplan-list"), {"location": location_query.ewkt}
+        reverse("v1:mountplan-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -54,7 +54,7 @@ def test_filter_error_mount_plans_location(location, location_query, expected):
 
     get_mount_plan(location)
     response = api_client.get(
-        reverse("api:mountplan-list"), {"location": location_query}
+        reverse("v1:mountplan-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -69,7 +69,7 @@ class MountPlanTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_mount_plan()
-        response = self.client.get(reverse("api:mountplan-list"))
+        response = self.client.get(reverse("v1:mountplan-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -86,7 +86,7 @@ class MountPlanTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_mount_plan()
         response = self.client.get(
-            reverse("api:mountplan-list"), data={"geo_format": "geojson"}
+            reverse("v1:mountplan-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -104,7 +104,7 @@ class MountPlanTests(TrafficControlAPIBaseTestCase):
         """
         mount_plan = self.__create_test_mount_plan()
         response = self.client.get(
-            reverse("api:mountplan-detail", kwargs={"pk": mount_plan.id})
+            reverse("v1:mountplan-detail", kwargs={"pk": mount_plan.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(mount_plan.id))
@@ -116,7 +116,7 @@ class MountPlanTests(TrafficControlAPIBaseTestCase):
         """
         mount_plan = self.__create_test_mount_plan()
         response = self.client.get(
-            reverse("api:mountplan-detail", kwargs={"pk": mount_plan.id}),
+            reverse("v1:mountplan-detail", kwargs={"pk": mount_plan.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -135,7 +135,7 @@ class MountPlanTests(TrafficControlAPIBaseTestCase):
             "lifecycle": self.test_lifecycle.value,
             "owner": self.test_owner,
         }
-        response = self.client.post(reverse("api:mountplan-list"), data, format="json")
+        response = self.client.post(reverse("v1:mountplan-list"), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(MountPlan.objects.count(), 1)
         self.assertEqual(response.data.get("location"), data["location"])
@@ -160,7 +160,7 @@ class MountPlanTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:mountplan-detail", kwargs={"pk": mount_plan.id}),
+            reverse("v1:mountplan-detail", kwargs={"pk": mount_plan.id}),
             data,
             format="json",
         )
@@ -180,7 +180,7 @@ class MountPlanTests(TrafficControlAPIBaseTestCase):
         """
         mount_plan = self.__create_test_mount_plan()
         response = self.client.delete(
-            reverse("api:mountplan-detail", kwargs={"pk": mount_plan.id}),
+            reverse("v1:mountplan-detail", kwargs={"pk": mount_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(MountPlan.objects.count(), 1)
@@ -193,11 +193,11 @@ class MountPlanTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_mount_plan_returns_not_found(self):
         mount_plan = self.__create_test_mount_plan()
         response = self.client.delete(
-            reverse("api:mountplan-detail", kwargs={"pk": mount_plan.id}),
+            reverse("v1:mountplan-detail", kwargs={"pk": mount_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:mountplan-detail", kwargs={"pk": mount_plan.id}),
+            reverse("v1:mountplan-detail", kwargs={"pk": mount_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -225,7 +225,7 @@ def test_filter_mount_reals_location(location, location_query, expected):
 
     mount_real = get_mount_real(location)
     response = api_client.get(
-        reverse("api:mountreal-list"), {"location": location_query.ewkt}
+        reverse("v1:mountreal-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -249,7 +249,7 @@ def test_filter_error_mount_reals_location(location, location_query, expected):
 
     get_mount_real(location)
     response = api_client.get(
-        reverse("api:mountreal-list"), {"location": location_query}
+        reverse("v1:mountreal-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -264,7 +264,7 @@ class MountRealTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_mount_real()
-        response = self.client.get(reverse("api:mountreal-list"))
+        response = self.client.get(reverse("v1:mountreal-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -281,7 +281,7 @@ class MountRealTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_mount_real()
         response = self.client.get(
-            reverse("api:mountreal-list"), data={"geo_format": "geojson"}
+            reverse("v1:mountreal-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -299,7 +299,7 @@ class MountRealTests(TrafficControlAPIBaseTestCase):
         """
         mount_real = self.__create_test_mount_real()
         response = self.client.get(
-            reverse("api:mountreal-detail", kwargs={"pk": mount_real.id})
+            reverse("v1:mountreal-detail", kwargs={"pk": mount_real.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(mount_real.id))
@@ -310,7 +310,7 @@ class MountRealTests(TrafficControlAPIBaseTestCase):
         """
         mount_real = self.__create_test_mount_real()
         response = self.client.get(
-            reverse("api:mountreal-detail", kwargs={"pk": mount_real.id}),
+            reverse("v1:mountreal-detail", kwargs={"pk": mount_real.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -329,7 +329,7 @@ class MountRealTests(TrafficControlAPIBaseTestCase):
             "lifecycle": self.test_lifecycle.value,
             "owner": self.test_owner,
         }
-        response = self.client.post(reverse("api:mountreal-list"), data, format="json")
+        response = self.client.post(reverse("v1:mountreal-list"), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(MountReal.objects.count(), 1)
         self.assertEqual(response.data.get("location"), data["location"])
@@ -355,7 +355,7 @@ class MountRealTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:mountreal-detail", kwargs={"pk": mount_real.id}),
+            reverse("v1:mountreal-detail", kwargs={"pk": mount_real.id}),
             data,
             format="json",
         )
@@ -376,7 +376,7 @@ class MountRealTests(TrafficControlAPIBaseTestCase):
         """
         mount_real = self.__create_test_mount_real()
         response = self.client.delete(
-            reverse("api:mountreal-detail", kwargs={"pk": mount_real.id}),
+            reverse("v1:mountreal-detail", kwargs={"pk": mount_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(MountReal.objects.count(), 1)
@@ -389,11 +389,11 @@ class MountRealTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_mount_real_returns_not_found(self):
         mount_real = self.__create_test_mount_real()
         response = self.client.delete(
-            reverse("api:mountreal-detail", kwargs={"pk": mount_real.id}),
+            reverse("v1:mountreal-detail", kwargs={"pk": mount_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:mountreal-detail", kwargs={"pk": mount_real.id}),
+            reverse("v1:mountreal-detail", kwargs={"pk": mount_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/traffic_control/tests/test_portal_type_api.py
+++ b/traffic_control/tests/test_portal_type_api.py
@@ -24,7 +24,7 @@ class PortalTypeTests(APITestCase):
             PortalType.objects.create(
                 structure="Test structure", build_type="Test build type", model=i
             )
-        response = self.client.get(reverse("api:portaltype-list"))
+        response = self.client.get(reverse("v1:portaltype-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -38,7 +38,7 @@ class PortalTypeTests(APITestCase):
             PortalType.objects.create(
                 structure="Test structure", build_type="Test build type", model=i
             )
-        response = self.client.get(reverse("api:portaltype-list"))
+        response = self.client.get(reverse("v1:portaltype-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -49,7 +49,7 @@ class PortalTypeTests(APITestCase):
         self.client.force_login(self.user)
         portal_type = self.__create_test_portal_type()
         response = self.client.get(
-            reverse("api:portaltype-detail", kwargs={"pk": portal_type.id})
+            reverse("v1:portaltype-detail", kwargs={"pk": portal_type.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(portal_type.id))
@@ -61,7 +61,7 @@ class PortalTypeTests(APITestCase):
         self.client.force_login(self.admin_user)
         portal_type = self.__create_test_portal_type()
         response = self.client.get(
-            reverse("api:portaltype-detail", kwargs={"pk": portal_type.id})
+            reverse("v1:portaltype-detail", kwargs={"pk": portal_type.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(portal_type.id))
@@ -72,7 +72,7 @@ class PortalTypeTests(APITestCase):
         """
         self.client.force_login(self.user)
         data = {"structure": "Putki", "build_type": "kehä", "model": "tyyppi I"}
-        response = self.client.post(reverse("api:portaltype-list"), data, format="json")
+        response = self.client.post(reverse("v1:portaltype-list"), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(PortalType.objects.count(), 0)
 
@@ -82,7 +82,7 @@ class PortalTypeTests(APITestCase):
         """
         self.client.force_login(self.admin_user)
         data = {"structure": "Putki", "build_type": "kehä", "model": "tyyppi I"}
-        response = self.client.post(reverse("api:portaltype-list"), data, format="json")
+        response = self.client.post(reverse("v1:portaltype-list"), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(PortalType.objects.count(), 1)
         portal_type = PortalType.objects.first()
@@ -95,9 +95,9 @@ class PortalTypeTests(APITestCase):
         Ensure that API will not create a new portal type object with same values.
         """
         data = {"structure": "Putki", "build_type": "kehä", "model": "tyyppi I"}
-        response = self.client.post(reverse("api:portaltype-list"), data, format="json")
+        response = self.client.post(reverse("v1:portaltype-list"), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        response = self.client.post(reverse("api:portaltype-list"), data, format="json")
+        response = self.client.post(reverse("v1:portaltype-list"), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(PortalType.objects.count(), 1)
         portal_type = PortalType.objects.first()
@@ -113,7 +113,7 @@ class PortalTypeTests(APITestCase):
         portal_type = self.__create_test_portal_type()
         data = {"structure": "Putki", "build_type": "kehä", "model": "tyyppi I"}
         response = self.client.put(
-            reverse("api:portaltype-detail", kwargs={"pk": portal_type.id}),
+            reverse("v1:portaltype-detail", kwargs={"pk": portal_type.id}),
             data,
             format="json",
         )
@@ -127,7 +127,7 @@ class PortalTypeTests(APITestCase):
         portal_type = self.__create_test_portal_type()
         data = {"structure": "Putki", "build_type": "kehä", "model": "tyyppi I"}
         response = self.client.put(
-            reverse("api:portaltype-detail", kwargs={"pk": portal_type.id}),
+            reverse("v1:portaltype-detail", kwargs={"pk": portal_type.id}),
             data,
             format="json",
         )
@@ -145,7 +145,7 @@ class PortalTypeTests(APITestCase):
         self.client.force_login(self.user)
         portal_type = self.__create_test_portal_type()
         response = self.client.delete(
-            reverse("api:portaltype-detail", kwargs={"pk": portal_type.id}),
+            reverse("v1:portaltype-detail", kwargs={"pk": portal_type.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(PortalType.objects.count(), 1)
@@ -157,7 +157,7 @@ class PortalTypeTests(APITestCase):
         self.client.force_login(self.admin_user)
         portal_type = self.__create_test_portal_type()
         response = self.client.delete(
-            reverse("api:portaltype-detail", kwargs={"pk": portal_type.id}),
+            reverse("v1:portaltype-detail", kwargs={"pk": portal_type.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(PortalType.objects.count(), 0)

--- a/traffic_control/tests/test_road_marking_api.py
+++ b/traffic_control/tests/test_road_marking_api.py
@@ -30,7 +30,7 @@ def test_filter_road_markings_plans_location(location, location_query, expected)
 
     road_marking_plan = get_road_marking_plan(location)
     response = api_client.get(
-        reverse("api:roadmarkingplan-list"), {"location": location_query.ewkt}
+        reverse("v1:roadmarkingplan-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -54,7 +54,7 @@ def test_filter_error_road_markings_plans_location(location, location_query, exp
 
     get_road_marking_plan(location)
     response = api_client.get(
-        reverse("api:roadmarkingplan-list"), {"location": location_query}
+        reverse("v1:roadmarkingplan-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -69,7 +69,7 @@ class RoadMarkingPlanTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_road_marking_plan()
-        response = self.client.get(reverse("api:roadmarkingplan-list"))
+        response = self.client.get(reverse("v1:roadmarkingplan-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -86,7 +86,7 @@ class RoadMarkingPlanTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_road_marking_plan()
         response = self.client.get(
-            reverse("api:roadmarkingplan-list"), data={"geo_format": "geojson"}
+            reverse("v1:roadmarkingplan-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -104,7 +104,7 @@ class RoadMarkingPlanTests(TrafficControlAPIBaseTestCase):
         """
         road_marking = self.__create_test_road_marking_plan()
         response = self.client.get(
-            reverse("api:roadmarkingplan-detail", kwargs={"pk": road_marking.id})
+            reverse("v1:roadmarkingplan-detail", kwargs={"pk": road_marking.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(road_marking.id))
@@ -116,7 +116,7 @@ class RoadMarkingPlanTests(TrafficControlAPIBaseTestCase):
         """
         road_marking = self.__create_test_road_marking_plan()
         response = self.client.get(
-            reverse("api:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
+            reverse("v1:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -136,7 +136,7 @@ class RoadMarkingPlanTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.post(
-            reverse("api:roadmarkingplan-list"), data, format="json"
+            reverse("v1:roadmarkingplan-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(RoadMarkingPlan.objects.count(), 1)
@@ -162,7 +162,7 @@ class RoadMarkingPlanTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
+            reverse("v1:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
             data,
             format="json",
         )
@@ -182,7 +182,7 @@ class RoadMarkingPlanTests(TrafficControlAPIBaseTestCase):
         """
         road_marking = self.__create_test_road_marking_plan()
         response = self.client.delete(
-            reverse("api:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
+            reverse("v1:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(RoadMarkingPlan.objects.count(), 1)
@@ -195,11 +195,11 @@ class RoadMarkingPlanTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_road_marking_return_not_found(self):
         road_marking = self.__create_test_road_marking_plan()
         response = self.client.delete(
-            reverse("api:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
+            reverse("v1:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
+            reverse("v1:roadmarkingplan-detail", kwargs={"pk": road_marking.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -234,7 +234,7 @@ def test_filter_road_markings_reals_location(location, location_query, expected)
 
     road_marking_real = get_road_marking_real(location)
     response = api_client.get(
-        reverse("api:roadmarkingreal-list"), {"location": location_query.ewkt}
+        reverse("v1:roadmarkingreal-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -258,7 +258,7 @@ def test_filter_error_road_markings_reals_location(location, location_query, exp
 
     get_road_marking_real(location)
     response = api_client.get(
-        reverse("api:roadmarkingreal-list"), {"location": location_query}
+        reverse("v1:roadmarkingreal-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -273,7 +273,7 @@ class RoadMarkingRealTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_road_marking_real()
-        response = self.client.get(reverse("api:roadmarkingreal-list"))
+        response = self.client.get(reverse("v1:roadmarkingreal-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -290,7 +290,7 @@ class RoadMarkingRealTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_road_marking_real()
         response = self.client.get(
-            reverse("api:roadmarkingreal-list"), data={"geo_format": "geojson"}
+            reverse("v1:roadmarkingreal-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -308,7 +308,7 @@ class RoadMarkingRealTests(TrafficControlAPIBaseTestCase):
         """
         road_marking_real = self.__create_test_road_marking_real()
         response = self.client.get(
-            reverse("api:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id})
+            reverse("v1:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(road_marking_real.id))
@@ -320,7 +320,7 @@ class RoadMarkingRealTests(TrafficControlAPIBaseTestCase):
         """
         road_marking_real = self.__create_test_road_marking_real()
         response = self.client.get(
-            reverse("api:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
+            reverse("v1:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -340,7 +340,7 @@ class RoadMarkingRealTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.post(
-            reverse("api:roadmarkingreal-list"), data, format="json"
+            reverse("v1:roadmarkingreal-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(RoadMarkingReal.objects.count(), 1)
@@ -367,7 +367,7 @@ class RoadMarkingRealTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
+            reverse("v1:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
             data,
             format="json",
         )
@@ -388,7 +388,7 @@ class RoadMarkingRealTests(TrafficControlAPIBaseTestCase):
         """
         road_marking_real = self.__create_test_road_marking_real()
         response = self.client.delete(
-            reverse("api:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
+            reverse("v1:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(RoadMarkingReal.objects.count(), 1)
@@ -403,11 +403,11 @@ class RoadMarkingRealTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_road_marking_real_returns_not_found(self):
         road_marking_real = self.__create_test_road_marking_real()
         response = self.client.delete(
-            reverse("api:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
+            reverse("v1:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
+            reverse("v1:roadmarkingreal-detail", kwargs={"pk": road_marking_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/traffic_control/tests/test_signpost_api.py
+++ b/traffic_control/tests/test_signpost_api.py
@@ -27,7 +27,7 @@ def test_filter_signpost_plan_location(location, location_query, expected):
 
     signpost_plan = get_signpost_plan(location)
     response = api_client.get(
-        reverse("api:signpostplan-list"), {"location": location_query.ewkt}
+        reverse("v1:signpostplan-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -50,7 +50,7 @@ def test_filter_error_signpost_plans_location(location, location_query, expected
 
     get_signpost_plan(location)
     response = api_client.get(
-        reverse("api:signpostplan-list"), {"location": location_query}
+        reverse("v1:signpostplan-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -65,7 +65,7 @@ class SignpostPlanTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_signpost_plan()
-        response = self.client.get(reverse("api:signpostplan-list"))
+        response = self.client.get(reverse("v1:signpostplan-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -82,7 +82,7 @@ class SignpostPlanTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_signpost_plan()
         response = self.client.get(
-            reverse("api:signpostplan-list"), data={"geo_format": "geojson"}
+            reverse("v1:signpostplan-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -100,7 +100,7 @@ class SignpostPlanTests(TrafficControlAPIBaseTestCase):
         """
         signpost_plan = self.__create_test_signpost_plan()
         response = self.client.get(
-            reverse("api:signpostplan-detail", kwargs={"pk": signpost_plan.id})
+            reverse("v1:signpostplan-detail", kwargs={"pk": signpost_plan.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(signpost_plan.id))
@@ -112,7 +112,7 @@ class SignpostPlanTests(TrafficControlAPIBaseTestCase):
         """
         signpost_plan = self.__create_test_signpost_plan()
         response = self.client.get(
-            reverse("api:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
+            reverse("v1:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -132,7 +132,7 @@ class SignpostPlanTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.post(
-            reverse("api:signpostplan-list"), data, format="json"
+            reverse("v1:signpostplan-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(SignpostPlan.objects.count(), 1)
@@ -158,7 +158,7 @@ class SignpostPlanTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
+            reverse("v1:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
             data,
             format="json",
         )
@@ -178,7 +178,7 @@ class SignpostPlanTests(TrafficControlAPIBaseTestCase):
         """
         signpost_plan = self.__create_test_signpost_plan()
         response = self.client.delete(
-            reverse("api:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
+            reverse("v1:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(SignpostPlan.objects.count(), 1)
@@ -191,11 +191,11 @@ class SignpostPlanTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_signpost_plan_returns_not_found(self):
         signpost_plan = self.__create_test_signpost_plan()
         response = self.client.delete(
-            reverse("api:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
+            reverse("v1:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
+            reverse("v1:signpostplan-detail", kwargs={"pk": signpost_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -222,7 +222,7 @@ def test_filter_signpost_reals_location(location, location_query, expected):
 
     signpost_real = get_signpost_real(location)
     response = api_client.get(
-        reverse("api:signpostreal-list"), {"location": location_query.ewkt}
+        reverse("v1:signpostreal-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -245,7 +245,7 @@ def test_filter_error_signpost_reals_location(location, location_query, expected
 
     get_signpost_real(location)
     response = api_client.get(
-        reverse("api:signpostreal-list"), {"location": location_query}
+        reverse("v1:signpostreal-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -260,7 +260,7 @@ class SignPostRealTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_signpost_real()
-        response = self.client.get(reverse("api:signpostreal-list"))
+        response = self.client.get(reverse("v1:signpostreal-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -277,7 +277,7 @@ class SignPostRealTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_signpost_real()
         response = self.client.get(
-            reverse("api:signpostreal-list"), data={"geo_format": "geojson"}
+            reverse("v1:signpostreal-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -295,7 +295,7 @@ class SignPostRealTests(TrafficControlAPIBaseTestCase):
         """
         signpost_real = self.__create_test_signpost_real()
         response = self.client.get(
-            reverse("api:signpostreal-detail", kwargs={"pk": signpost_real.id})
+            reverse("v1:signpostreal-detail", kwargs={"pk": signpost_real.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(signpost_real.id))
@@ -307,7 +307,7 @@ class SignPostRealTests(TrafficControlAPIBaseTestCase):
         """
         signpost_real = self.__create_test_signpost_real()
         response = self.client.get(
-            reverse("api:signpostreal-detail", kwargs={"pk": signpost_real.id}),
+            reverse("v1:signpostreal-detail", kwargs={"pk": signpost_real.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -327,7 +327,7 @@ class SignPostRealTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.post(
-            reverse("api:signpostreal-list"), data, format="json"
+            reverse("v1:signpostreal-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(SignpostReal.objects.count(), 1)
@@ -354,7 +354,7 @@ class SignPostRealTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:signpostreal-detail", kwargs={"pk": signpost_real.id}),
+            reverse("v1:signpostreal-detail", kwargs={"pk": signpost_real.id}),
             data,
             format="json",
         )
@@ -375,7 +375,7 @@ class SignPostRealTests(TrafficControlAPIBaseTestCase):
         """
         signpost_real = self.__create_test_signpost_real()
         response = self.client.delete(
-            reverse("api:signpostreal-detail", kwargs={"pk": signpost_real.id}),
+            reverse("v1:signpostreal-detail", kwargs={"pk": signpost_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(SignpostReal.objects.count(), 1)
@@ -388,11 +388,11 @@ class SignPostRealTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_signpost_real_returns_not_found(self):
         signpost_real = self.__create_test_signpost_real()
         response = self.client.delete(
-            reverse("api:signpostreal-detail", kwargs={"pk": signpost_real.id}),
+            reverse("v1:signpostreal-detail", kwargs={"pk": signpost_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:signpostreal-detail", kwargs={"pk": signpost_real.id}),
+            reverse("v1:signpostreal-detail", kwargs={"pk": signpost_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/traffic_control/tests/test_traffic_light_api.py
+++ b/traffic_control/tests/test_traffic_light_api.py
@@ -323,9 +323,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         """
         traffic_light_real = self.__create_test_traffic_light_real()
         response = self.client.get(
-            reverse(
-                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
-            ),
+            reverse("v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -375,9 +373,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse(
-                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
-            ),
+            reverse("v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}),
             data,
             format="json",
         )
@@ -399,9 +395,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         """
         traffic_light_real = self.__create_test_traffic_light_real()
         response = self.client.delete(
-            reverse(
-                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
-            ),
+            reverse("v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(TrafficLightReal.objects.count(), 1)
@@ -416,15 +410,11 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_traffic_light_real_returns_not_found(self):
         traffic_light_real = self.__create_test_traffic_light_real()
         response = self.client.delete(
-            reverse(
-                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
-            ),
+            reverse("v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse(
-                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
-            ),
+            reverse("v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/traffic_control/tests/test_traffic_light_api.py
+++ b/traffic_control/tests/test_traffic_light_api.py
@@ -33,7 +33,7 @@ def test_filter_traffic_light_plans_location(location, location_query, expected)
 
     traffic_light_plan = get_traffic_light_plan(location)
     response = api_client.get(
-        reverse("api:trafficlightplan-list"), {"location": location_query.ewkt}
+        reverse("v1:trafficlightplan-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -56,7 +56,7 @@ def test_filter_error_traffic_light_plans_location(location, location_query, exp
 
     get_traffic_light_plan(location)
     response = api_client.get(
-        reverse("api:trafficlightplan-list"), {"location": location_query}
+        reverse("v1:trafficlightplan-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -71,7 +71,7 @@ class TrafficLightPlanTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_traffic_light_plan()
-        response = self.client.get(reverse("api:trafficlightplan-list"))
+        response = self.client.get(reverse("v1:trafficlightplan-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -88,7 +88,7 @@ class TrafficLightPlanTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_traffic_light_plan()
         response = self.client.get(
-            reverse("api:trafficlightplan-list"), data={"geo_format": "geojson"}
+            reverse("v1:trafficlightplan-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -106,7 +106,7 @@ class TrafficLightPlanTests(TrafficControlAPIBaseTestCase):
         """
         traffic_light = self.__create_test_traffic_light_plan()
         response = self.client.get(
-            reverse("api:trafficlightplan-detail", kwargs={"pk": traffic_light.id})
+            reverse("v1:trafficlightplan-detail", kwargs={"pk": traffic_light.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(traffic_light.id))
@@ -118,7 +118,7 @@ class TrafficLightPlanTests(TrafficControlAPIBaseTestCase):
         """
         traffic_light = self.__create_test_traffic_light_plan()
         response = self.client.get(
-            reverse("api:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
+            reverse("v1:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -139,7 +139,7 @@ class TrafficLightPlanTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.post(
-            reverse("api:trafficlightplan-list"), data, format="json"
+            reverse("v1:trafficlightplan-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(TrafficLightPlan.objects.count(), 1)
@@ -167,7 +167,7 @@ class TrafficLightPlanTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
+            reverse("v1:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
             data,
             format="json",
         )
@@ -188,7 +188,7 @@ class TrafficLightPlanTests(TrafficControlAPIBaseTestCase):
         """
         traffic_light = self.__create_test_traffic_light_plan()
         response = self.client.delete(
-            reverse("api:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
+            reverse("v1:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(TrafficLightPlan.objects.count(), 1)
@@ -201,11 +201,11 @@ class TrafficLightPlanTests(TrafficControlAPIBaseTestCase):
     def test_get_deleted_traffic_light_plan_return_not_found(self):
         traffic_light = self.__create_test_traffic_light_plan()
         response = self.client.delete(
-            reverse("api:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
+            reverse("v1:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
+            reverse("v1:trafficlightplan-detail", kwargs={"pk": traffic_light.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -236,7 +236,7 @@ def test_filter_traffic_light_reals_location(location, location_query, expected)
 
     traffic_light_real = get_traffic_light_real(location)
     response = api_client.get(
-        reverse("api:trafficlightreal-list"), {"location": location_query.ewkt}
+        reverse("v1:trafficlightreal-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -259,7 +259,7 @@ def test_filter_error_traffic_light_reals_location(location, location_query, exp
 
     get_traffic_light_real(location)
     response = api_client.get(
-        reverse("api:trafficlightreal-list"), {"location": location_query}
+        reverse("v1:trafficlightreal-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -274,7 +274,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         count = 3
         for i in range(count):
             self.__create_test_traffic_light_real()
-        response = self.client.get(reverse("api:trafficlightreal-list"))
+        response = self.client.get(reverse("v1:trafficlightreal-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -291,7 +291,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         for i in range(count):
             self.__create_test_traffic_light_real()
         response = self.client.get(
-            reverse("api:trafficlightreal-list"), data={"geo_format": "geojson"}
+            reverse("v1:trafficlightreal-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -309,7 +309,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         """
         traffic_light_real = self.__create_test_traffic_light_real()
         response = self.client.get(
-            reverse("api:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id})
+            reverse("v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(traffic_light_real.id))
@@ -324,7 +324,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         traffic_light_real = self.__create_test_traffic_light_real()
         response = self.client.get(
             reverse(
-                "api:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
+                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
             ),
             data={"geo_format": "geojson"},
         )
@@ -346,7 +346,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
             "owner": self.test_owner,
         }
         response = self.client.post(
-            reverse("api:trafficlightreal-list"), data, format="json"
+            reverse("v1:trafficlightreal-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(TrafficLightReal.objects.count(), 1)
@@ -376,7 +376,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         }
         response = self.client.put(
             reverse(
-                "api:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
+                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
             ),
             data,
             format="json",
@@ -400,7 +400,7 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         traffic_light_real = self.__create_test_traffic_light_real()
         response = self.client.delete(
             reverse(
-                "api:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
+                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
             ),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -417,13 +417,13 @@ class TrafficLightRealTests(TrafficControlAPIBaseTestCase):
         traffic_light_real = self.__create_test_traffic_light_real()
         response = self.client.delete(
             reverse(
-                "api:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
+                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
             ),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
             reverse(
-                "api:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
+                "v1:trafficlightreal-detail", kwargs={"pk": traffic_light_real.id}
             ),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/traffic_control/tests/test_traffic_sign_api.py
+++ b/traffic_control/tests/test_traffic_sign_api.py
@@ -27,7 +27,7 @@ def test_filter_traffic_sign_plans_location(location, location_query, expected):
 
     traffic_sign_plan = get_traffic_sign_plan(location)
     response = api_client.get(
-        reverse("api:trafficsignplan-list"), {"location": location_query.ewkt}
+        reverse("v1:trafficsignplan-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -50,7 +50,7 @@ def test_filter_error_traffic_sign_plans_location(location, location_query, expe
 
     get_traffic_sign_plan(location)
     response = api_client.get(
-        reverse("api:trafficsignplan-list"), {"location": location_query}
+        reverse("v1:trafficsignplan-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -65,7 +65,7 @@ class TrafficSignPlanTests(TrafficControlAPIBaseTestCase3D):
         count = 3
         for i in range(count):
             self.__create_test_traffic_sign_plan()
-        response = self.client.get(reverse("api:trafficsignplan-list"))
+        response = self.client.get(reverse("v1:trafficsignplan-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -82,7 +82,7 @@ class TrafficSignPlanTests(TrafficControlAPIBaseTestCase3D):
         for i in range(count):
             self.__create_test_traffic_sign_plan()
         response = self.client.get(
-            reverse("api:trafficsignplan-list"), data={"geo_format": "geojson"}
+            reverse("v1:trafficsignplan-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -100,7 +100,7 @@ class TrafficSignPlanTests(TrafficControlAPIBaseTestCase3D):
         """
         traffic_sign_plan = self.__create_test_traffic_sign_plan()
         response = self.client.get(
-            reverse("api:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id})
+            reverse("v1:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(traffic_sign_plan.id))
@@ -112,7 +112,7 @@ class TrafficSignPlanTests(TrafficControlAPIBaseTestCase3D):
         """
         traffic_sign_plan = self.__create_test_traffic_sign_plan()
         response = self.client.get(
-            reverse("api:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
+            reverse("v1:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -132,7 +132,7 @@ class TrafficSignPlanTests(TrafficControlAPIBaseTestCase3D):
             "owner": self.test_owner,
         }
         response = self.client.post(
-            reverse("api:trafficsignplan-list"), data, format="json"
+            reverse("v1:trafficsignplan-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(TrafficSignPlan.objects.count(), 1)
@@ -158,7 +158,7 @@ class TrafficSignPlanTests(TrafficControlAPIBaseTestCase3D):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
+            reverse("v1:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
             data,
             format="json",
         )
@@ -178,7 +178,7 @@ class TrafficSignPlanTests(TrafficControlAPIBaseTestCase3D):
         """
         traffic_sign_plan = self.__create_test_traffic_sign_plan()
         response = self.client.delete(
-            reverse("api:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
+            reverse("v1:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(TrafficSignPlan.objects.count(), 1)
@@ -193,11 +193,11 @@ class TrafficSignPlanTests(TrafficControlAPIBaseTestCase3D):
     def test_get_deleted_traffic_sign_plan_returns_not_found(self):
         traffic_sign_plan = self.__create_test_traffic_sign_plan()
         response = self.client.delete(
-            reverse("api:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
+            reverse("v1:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
+            reverse("v1:trafficsignplan-detail", kwargs={"pk": traffic_sign_plan.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -224,7 +224,7 @@ def test_filter_traffic_sign_reals_location(location, location_query, expected):
 
     traffic_sign_real = get_traffic_sign_real(location)
     response = api_client.get(
-        reverse("api:trafficsignreal-list"), {"location": location_query.ewkt}
+        reverse("v1:trafficsignreal-list"), {"location": location_query.ewkt}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -247,7 +247,7 @@ def test_filter_error_traffic_sign_reals_location(location, location_query, expe
 
     get_traffic_sign_real(location)
     response = api_client.get(
-        reverse("api:trafficsignreal-list"), {"location": location_query}
+        reverse("v1:trafficsignreal-list"), {"location": location_query}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -262,7 +262,7 @@ class TrafficSignRealTests(TrafficControlAPIBaseTestCase3D):
         count = 3
         for i in range(count):
             self.__create_test_traffic_sign_real()
-        response = self.client.get(reverse("api:trafficsignreal-list"))
+        response = self.client.get(reverse("v1:trafficsignreal-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -279,7 +279,7 @@ class TrafficSignRealTests(TrafficControlAPIBaseTestCase3D):
         for i in range(count):
             self.__create_test_traffic_sign_real()
         response = self.client.get(
-            reverse("api:trafficsignreal-list"), data={"geo_format": "geojson"}
+            reverse("v1:trafficsignreal-list"), data={"geo_format": "geojson"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
@@ -297,7 +297,7 @@ class TrafficSignRealTests(TrafficControlAPIBaseTestCase3D):
         """
         traffic_sign_real = self.__create_test_traffic_sign_real()
         response = self.client.get(
-            reverse("api:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id})
+            reverse("v1:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(traffic_sign_real.id))
@@ -309,7 +309,7 @@ class TrafficSignRealTests(TrafficControlAPIBaseTestCase3D):
         """
         traffic_sign_real = self.__create_test_traffic_sign_real()
         response = self.client.get(
-            reverse("api:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
+            reverse("v1:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
             data={"geo_format": "geojson"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -331,7 +331,7 @@ class TrafficSignRealTests(TrafficControlAPIBaseTestCase3D):
             "owner": self.test_owner,
         }
         response = self.client.post(
-            reverse("api:trafficsignreal-list"), data, format="json"
+            reverse("v1:trafficsignreal-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(TrafficSignReal.objects.count(), 1)
@@ -360,7 +360,7 @@ class TrafficSignRealTests(TrafficControlAPIBaseTestCase3D):
             "owner": self.test_owner,
         }
         response = self.client.put(
-            reverse("api:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
+            reverse("v1:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
             data,
             format="json",
         )
@@ -381,7 +381,7 @@ class TrafficSignRealTests(TrafficControlAPIBaseTestCase3D):
         """
         traffic_sign_real = self.__create_test_traffic_sign_real()
         response = self.client.delete(
-            reverse("api:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
+            reverse("v1:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(TrafficSignReal.objects.count(), 1)
@@ -396,11 +396,11 @@ class TrafficSignRealTests(TrafficControlAPIBaseTestCase3D):
     def test_get_deleted_traffic_sign_real_returns_not_found(self):
         traffic_sign_real = self.__create_test_traffic_sign_real()
         response = self.client.delete(
-            reverse("api:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
+            reverse("v1:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(
-            reverse("api:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
+            reverse("v1:trafficsignreal-detail", kwargs={"pk": traffic_sign_real.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/traffic_control/tests/test_traffic_sign_code_api.py
+++ b/traffic_control/tests/test_traffic_sign_code_api.py
@@ -23,7 +23,7 @@ class TrafficSignCodeTests(APITestCase):
             TrafficSignCode.objects.create(
                 code=i, description="Test description %s" % i,
             )
-        response = self.client.get(reverse("api:trafficsigncode-list"))
+        response = self.client.get(reverse("v1:trafficsigncode-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -37,7 +37,7 @@ class TrafficSignCodeTests(APITestCase):
             TrafficSignCode.objects.create(
                 code=i, description="Test description %s" % i,
             )
-        response = self.client.get(reverse("api:trafficsigncode-list"))
+        response = self.client.get(reverse("v1:trafficsigncode-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count)
 
@@ -48,7 +48,7 @@ class TrafficSignCodeTests(APITestCase):
         self.client.force_login(self.user)
         traffic_sign_code = self.__create_test_traffic_sign_code()
         response = self.client.get(
-            reverse("api:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id})
+            reverse("v1:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(traffic_sign_code.id))
@@ -60,7 +60,7 @@ class TrafficSignCodeTests(APITestCase):
         self.client.force_login(self.admin_user)
         traffic_sign_code = self.__create_test_traffic_sign_code()
         response = self.client.get(
-            reverse("api:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id})
+            reverse("v1:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("id"), str(traffic_sign_code.id))
@@ -75,7 +75,7 @@ class TrafficSignCodeTests(APITestCase):
             "description": "Suojatie",
         }
         response = self.client.post(
-            reverse("api:trafficsigncode-list"), data, format="json"
+            reverse("v1:trafficsigncode-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(TrafficSignCode.objects.count(), 0)
@@ -90,7 +90,7 @@ class TrafficSignCodeTests(APITestCase):
             "description": "Suojatie",
         }
         response = self.client.post(
-            reverse("api:trafficsigncode-list"), data, format="json"
+            reverse("v1:trafficsigncode-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(TrafficSignCode.objects.count(), 1)
@@ -108,11 +108,11 @@ class TrafficSignCodeTests(APITestCase):
             "description": "Suojatie",
         }
         response = self.client.post(
-            reverse("api:trafficsigncode-list"), data, format="json"
+            reverse("v1:trafficsigncode-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response = self.client.post(
-            reverse("api:trafficsigncode-list"), data, format="json"
+            reverse("v1:trafficsigncode-list"), data, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(TrafficSignCode.objects.count(), 1)
@@ -131,7 +131,7 @@ class TrafficSignCodeTests(APITestCase):
             "description": "Suojatie",
         }
         response = self.client.put(
-            reverse("api:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id}),
+            reverse("v1:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id}),
             data,
             format="json",
         )
@@ -149,7 +149,7 @@ class TrafficSignCodeTests(APITestCase):
             "description": "Suojatie",
         }
         response = self.client.put(
-            reverse("api:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id}),
+            reverse("v1:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id}),
             data,
             format="json",
         )
@@ -166,7 +166,7 @@ class TrafficSignCodeTests(APITestCase):
         self.client.force_login(self.user)
         traffic_sign_code = self.__create_test_traffic_sign_code()
         response = self.client.delete(
-            reverse("api:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id}),
+            reverse("v1:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(TrafficSignCode.objects.count(), 1)
@@ -178,7 +178,7 @@ class TrafficSignCodeTests(APITestCase):
         self.client.force_login(self.admin_user)
         traffic_sign_code = self.__create_test_traffic_sign_code()
         response = self.client.delete(
-            reverse("api:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id}),
+            reverse("v1:trafficsigncode-detail", kwargs={"pk": traffic_sign_code.id}),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(TrafficSignCode.objects.count(), 0)

--- a/traffic_control/utils/send_portal_types.py
+++ b/traffic_control/utils/send_portal_types.py
@@ -18,7 +18,7 @@ parser.add_argument(
     "--url",
     required=True,
     type=str,
-    default="http://localhost:8000/fi/api/portal-types/",
+    default="http://localhost:8000/v1/portal-types/",
     help="API-endpoint url where to post the data",
 )
 parser.add_argument(

--- a/traffic_control/utils/send_traffic_sign_codes.py
+++ b/traffic_control/utils/send_traffic_sign_codes.py
@@ -18,7 +18,7 @@ parser.add_argument(
     "--url",
     required=True,
     type=str,
-    default="http://localhost:8000/fi/api/traffic-sign-codes/",
+    default="http://localhost:8000/v1/traffic-sign-codes/",
     help="API-endpoint url where to post the data",
 )
 parser.add_argument(

--- a/traffic_control/utils/send_traffic_sign_reals_blom_kartta.py
+++ b/traffic_control/utils/send_traffic_sign_reals_blom_kartta.py
@@ -43,7 +43,7 @@ parser.add_argument(
     "--url",
     required=True,
     type=str,
-    default="http://localhost:8000/fi/api/traffic-sign-reals/",
+    default="http://localhost:8000/v1/traffic-sign-reals/",
     help="API-endpoint url where to post the data",
 )
 parser.add_argument(

--- a/traffic_control/utils/send_traffic_sign_reals_vaisala.py
+++ b/traffic_control/utils/send_traffic_sign_reals_vaisala.py
@@ -31,7 +31,7 @@ parser.add_argument(
     "--url",
     required=True,
     type=str,
-    default="http://localhost:8000/fi/api/traffic-sign-reals/",
+    default="http://localhost:8000/v1/traffic-sign-reals/",
     help="API-endpoint url where to post the data",
 )
 parser.add_argument(


### PR DESCRIPTION
Change the api url from "/api" to "/v1" and change the api URL namespace
from "api" to "v1". Reflect this change anywhere where the url or
namespace is referenced.

Other Helsinki project API's follow this pattern so implement it for
this project as well.

Refs LIIK-122