### PR TITLE
Switch to limit-offset pagination

### DIFF
--- a/city-infrastructure-platform/settings.py
+++ b/city-infrastructure-platform/settings.py
@@ -186,9 +186,9 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
-    "PAGE_SIZE": 100,
+    "PAGE_SIZE": 20,
 }
 
 # django-cors

--- a/traffic_control/tests/factories.py
+++ b/traffic_control/tests/factories.py
@@ -228,8 +228,8 @@ def get_traffic_light_real(location=""):
     )[0]
 
 
-def get_traffic_sign_code():
-    return TrafficSignCode.objects.get_or_create(code="A11", description="Test")[0]
+def get_traffic_sign_code(code: str = "A11", description: str = "Test"):
+    return TrafficSignCode.objects.get_or_create(code=code, description=description)[0]
 
 
 def get_traffic_sign_plan(location="", plan=None):

--- a/traffic_control/tests/test_pagination.py
+++ b/traffic_control/tests/test_pagination.py
@@ -1,0 +1,35 @@
+import pytest
+from django.urls import reverse
+
+from .factories import get_api_client, get_traffic_sign_code
+
+
+@pytest.mark.django_db
+def test_limit_offset_pagination():
+    """
+    Test that pagination works as expected for one endpoint. The functionality
+    is global for all endpoints and it is completely included in Django Rest
+    Framework, so testing one endpoint is enough at the time of writing.
+
+    The point of this test is to detect possible regression caused by by future
+    updates.
+    """
+    api_client = get_api_client()
+    tsc_1 = get_traffic_sign_code(code="A1", description="foo")
+    tsc_2 = get_traffic_sign_code(code="A2", description="bar")
+    tsc_3 = get_traffic_sign_code(code="A3", description="baz")
+    tsc_4 = get_traffic_sign_code(code="A4", description="qux")
+    tsc_5 = get_traffic_sign_code(code="A5", description="quux")
+
+    response = api_client.get(
+        reverse("v1:trafficsigncode-list"), {"limit": 2, "offset": 2}
+    )
+
+    result_pks = [r["id"] for r in response.data["results"]]
+    assert response.data["count"] == 5
+    assert len(result_pks) == 2
+    assert str(tsc_3.pk) in result_pks
+    assert str(tsc_4.pk) in result_pks
+    assert str(tsc_1.pk) not in result_pks
+    assert str(tsc_2.pk) not in result_pks
+    assert str(tsc_5.pk) not in result_pks


### PR DESCRIPTION
Limit-offset pagination is more flexible pagination style that suits
the API better.

Add simple regression test so the pagination is not broken by accident
in future updates.

Refs LIIK-124