### PR TITLE
Set affect_area to not required for geojson format

### DIFF
--- a/traffic_control/serializers.py
+++ b/traffic_control/serializers.py
@@ -110,7 +110,7 @@ class TrafficSignPlanSerializer(
 
 class TrafficSignPlanGeoJSONSerializer(TrafficSignPlanSerializer):
     location = GeometryField()
-    affect_area = GeometryField()
+    affect_area = GeometryField(required=False)
 
 
 class TrafficSignRealFileSerializer(serializers.ModelSerializer):
@@ -137,7 +137,7 @@ class TrafficSignRealSerializer(
 
 class TrafficSignRealGeoJSONSerializer(TrafficSignRealSerializer):
     location = GeometryField()
-    affect_area = GeometryField()
+    affect_area = GeometryField(required=False)
 
 
 class SignpostPlanFileSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Traffic sign GeoJSON serializers had affect_area set to required
implicitly through the GeometryField defaults. Explicitly define the
field as not required as it is meant to be.

Refs LIIK-138