### PR TITLE
Add missing asterisk to Azure workaround glob

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,7 +24,7 @@ echo "Checking for odd ENTRYPOINT line in arguments"
 echo "Arguments are:"
 echo $@
 echo
-if [[ $@ == *"(nop)  ENTRYPOINT" ]]; then
+if [[ $@ == *"(nop)  ENTRYPOINT"* ]]; then
     echo "ENTRYPOINT found in arguments. Emptying arguments."
     set --
 else


### PR DESCRIPTION
Azure App Service workaround in docker-entrypoint.sh was missing the ending asterisk in glob match. Thus it did not work.