### PR TITLE
Increase uWSGI buffer-size

### DIFF
--- a/uwsgi_docker.ini
+++ b/uwsgi_docker.ini
@@ -3,3 +3,4 @@ http-socket = :8000
 chdir = /city-infrastructure-platform
 module = city-infrastructure-platform.wsgi
 static-map = /static=/city-infrastructure-platform/var/static
+buffer-size = 32768


### PR DESCRIPTION
Increase uWSGI buffer-size to 32k, since by default it is only 4k and not enough for our usage.

Refs LIIK-153