### PR TITLE
Add a utils method to get system user for importers

### DIFF
--- a/users/tests/test_utils.py
+++ b/users/tests/test_utils.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+
+from users.utils import get_system_user
+
+
+class GetSystemUserTestCase(TestCase):
+    def test_get_system_user_is_not_activated_and_not_staff(self):
+        user = get_system_user()
+        self.assertFalse(user.is_active)
+        self.assertFalse(user.is_staff)

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,0 +1,8 @@
+from .models import User
+
+
+def get_system_user():
+    user, _ = User.objects.get_or_create(
+        username="system", is_active=False, is_staff=False,
+    )
+    return user


### PR DESCRIPTION
Traffic control model instances require a created_by user. This util method
provides a inactive and non-staff user to fill the field when importing data
from data files.

no refs