### PR TITLE
Hide device type legacy attributes from API

### DIFF
--- a/traffic_control/serializers.py
+++ b/traffic_control/serializers.py
@@ -526,7 +526,7 @@ class TrafficControlDeviceTypeSerializer(
 ):
     class Meta:
         model = TrafficControlDeviceType
-        fields = "__all__"
+        exclude = ("legacy_code", "legacy_description")
 
     def validate_target_model(
         self, value: Optional[DeviceTypeTargetModel]


### PR DESCRIPTION
TrafficControlDeviceType legacy_code and legacy_descrpition should not
be accessible through the API so exclude them from the serializer
class.

Refs LIIK-154