### PR TITLE
Remove legacy_code exclude for main traffic signs

### DIFF
--- a/traffic_control/management/commands/generate_mount_real_objects.py
+++ b/traffic_control/management/commands/generate_mount_real_objects.py
@@ -23,12 +23,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write("Generating mount real objects ...")
-        # main traffic signs are those whose legacy code
-        # does not start with 8
-        main_traffic_signs = (
-            TrafficSignReal.objects.active()
-            .filter(mount_real__isnull=True, mount_type__isnull=False)
-            .exclude(legacy_code__startswith="8")
+        main_traffic_signs = TrafficSignReal.objects.active().filter(
+            mount_real__isnull=True, mount_type__isnull=False
         )
 
         for main_traffic_sign in main_traffic_signs:


### PR DESCRIPTION
The additional signs (legacy code starts with "8") are now stored in
separate model AdditionalSignReal, so there is no need to the exclude
any more.

Refs: LIIK-142