### PR TITLE
Update docker-compose to use .env-file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,6 @@ DEBUG=True
 SECRET_KEY=change-me
 DATABASE_URL=postgis://city-infrastructure-platform:city-infrastructure-platform@localhost/city-infrastructure-platform
 ALLOWED_HOSTS=127.0.0.1,localhost
+OIDC_AUTHENTICATION_ENABLED=False
 AZURE_DEPLOYMENT=False
 SENTRY_DSN=need-sentry

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ src/
 target/
 var/
 venv/
+*.xml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 services:
   db:
     image: mdillon/postgis:11-alpine
@@ -9,21 +9,13 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:
-      - "5433:5432"
+      - "5432:5432"
   api:
     build:
       target: development
       context: "."
-    volumes:
-      - .:/city-infrastructure-platform
-    environment:
-      - DEBUG=1
-      - DEV_SERVER=1
-      - APPLY_MIGRATIONS=1
-      - DATABASE_HOST=db
-      - DATABASE_PORT=5433
-      - DATABASE_URL=postgis://city-infrastructure-platform:city-infrastructure-platform@db/city-infrastructure-platform
-      - ALLOWED_HOSTS=127.0.0.1,localhost
+    env_file:
+        - .env
     ports:
       - "8000:8000"
     restart: on-failure

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ django-enumfields==2.0.0
 django-environ==0.4.5
 django-extensions==2.2.9
 django-filter==2.2.0
--e git+https://github.com/City-of-Helsinki/django-helusers@feature/logged_token#egg=django-helusers
+git+https://github.com/City-of-Helsinki/django-helusers@feature/logged_token#egg=django-helusers
 django-jsonfield==1.4.0   # via django-auditlog
 django-storages[azure]==1.9.1
 djangorestframework==3.11.0


### PR DESCRIPTION
Use .env-file instead of explicit environment variables.
Do not use editable version of django-helusers.
Update Docker Compose version.
Update .gitignore and .env.example settings.

Refs LIIK-157