### PR TITLE
Exclude legacy_code from AdditionalSignReal API

### DIFF
--- a/traffic_control/serializers.py
+++ b/traffic_control/serializers.py
@@ -222,7 +222,7 @@ class AdditionalSignRealSerializer(
             "deleted_by",
             "deleted_at",
         )
-        exclude = ("mount_type", "is_active", "deleted_at", "deleted_by")
+        exclude = ("mount_type", "legacy_code", "is_active", "deleted_at", "deleted_by")
 
 
 class AdditionalSignRealGeoJSONSerializer(AdditionalSignRealSerializer):


### PR DESCRIPTION
legacy_code should not have been exposed in the API in the first place.
The value is used only for imports and it should be of no interest for
end users.