### PR TITLE
Feature: Enable hard delete in django admin

### DIFF
--- a/traffic_control/admin/additional_sign.py
+++ b/traffic_control/admin/additional_sign.py
@@ -255,7 +255,7 @@ class AdditionalSignRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    list_filter = [
+    list_filter = SoftDeleteAdminMixin.list_filter + [
         ("lifecycle", EnumFieldListFilter),
         ("installation_status", EnumFieldListFilter),
         ("condition", EnumFieldListFilter),

--- a/traffic_control/admin/traffic_sign.py
+++ b/traffic_control/admin/traffic_sign.py
@@ -289,7 +289,7 @@ class TrafficSignRealAdmin(
         "updated_by",
     )
     ordering = ("-created_at",)
-    list_filter = [
+    list_filter = SoftDeleteAdminMixin.list_filter + [
         ("lifecycle", EnumFieldListFilter),
         ("installation_status", EnumFieldListFilter),
         ("condition", EnumFieldListFilter),

--- a/traffic_control/locale/fi/LC_MESSAGES/django.po
+++ b/traffic_control/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-17 13:45+0300\n"
+"POT-Creation-Date: 2020-07-21 14:43+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -96,6 +96,15 @@ msgstr "Liikennemerkki (suunnitelmat)"
 
 msgid "Additional Sign Plans"
 msgstr "Lisäkilpi (suunnitelmat)"
+
+msgid "Marked as deleted (hidden from API)"
+msgstr "Merkitty poistetuksi (piilotettu rajapinnasta)"
+
+msgid "Mark selected objects as deleted"
+msgstr "Merkitse valitut kohteet poistetuksi"
+
+msgid "Mark selected objects as not deleted"
+msgstr "Kumoa valittujen kohteiden poistettu merkintä"
 
 msgid "Active"
 msgstr "Pysyvä laite"


### PR DESCRIPTION
Previously Django admin was set to soft delete model instances if the
model was a soft deletable model. This was to be reverted because it
was thought that model instances should be deletable for real in django
admin. The API is still only able to soft delete.

However it should still be possible to do soft delete via Django admin.
Implement changelist actions to retain that feature with minimal effort.

Also implement a soft delete list filter that allows to list all soft
deleted instances and possibly recover them if necessary. Soft deleted
instances are hidden by default.

Refs LIIK-147