### PR TITLE
Add traffic_sign_type for TrafficControlDeviceType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - Permissions based on operational area
+- `traffic_sign_type` property for `TrafficControlDeviceType`
 
 ### Changed
 - Admin UI usability improvements

--- a/traffic_control/filters.py
+++ b/traffic_control/filters.py
@@ -1,4 +1,6 @@
 from django.contrib.gis.db.models import GeometryField
+from django.utils.translation import gettext_lazy as _
+from django_filters import ChoiceFilter
 from django_filters.rest_framework import FilterSet
 from rest_framework_gis.filters import GeometryFilter
 
@@ -24,6 +26,7 @@ from traffic_control.models import (
     TrafficSignPlan,
     TrafficSignReal,
 )
+from traffic_control.models.common import TRAFFIC_SIGN_TYPE_CHOICES
 
 
 class GenericMeta:
@@ -123,8 +126,19 @@ class TrafficLightRealFilterSet(FilterSet):
 
 
 class TrafficControlDeviceTypeFilterSet(FilterSet):
+    traffic_sign_type = ChoiceFilter(
+        label=_("Traffic sign type"),
+        choices=TRAFFIC_SIGN_TYPE_CHOICES,
+        method="filter_traffic_sign_type",
+    )
+
     class Meta(GenericMeta):
         model = TrafficControlDeviceType
+
+    def filter_traffic_sign_type(self, queryset, name, value):
+        if value:
+            queryset = queryset.filter(code__startswith=value)
+        return queryset
 
 
 class TrafficSignPlanFilterSet(FilterSet):

--- a/traffic_control/locale/fi/LC_MESSAGES/django.po
+++ b/traffic_control/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-28 14:43+0300\n"
+"POT-Creation-Date: 2020-07-30 12:12+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -75,6 +75,9 @@ msgstr "Sijainti (z)"
 
 msgid "Traffic control"
 msgstr "Liikenteenohjauslaitteet"
+
+msgid "Traffic sign type"
+msgstr "Liikennemerkkityyppi"
 
 msgid "Location (x,y)"
 msgstr "Sijainti (x,y)"
@@ -519,6 +522,30 @@ msgstr "Poikkisuuntainen"
 
 msgid "Other road marking"
 msgstr "Muu tiemerkintä"
+
+msgid "Warning sign"
+msgstr "Varoitusmerkki"
+
+msgid "Priority or give-way sign"
+msgstr "Etuajo-oikeus- tai väistämismerkki"
+
+msgid "Prohibitory or restrictive sign"
+msgstr "Kielto- tai rajoitusmerkki"
+
+msgid "Mandatory sign"
+msgstr "Määräysmerkki"
+
+msgid "Regulatory sign"
+msgstr "Sääntömerkki"
+
+msgid "Information sign"
+msgstr "Opastusmerkki"
+
+msgid "Service sign"
+msgstr "Palvelukohteen opastusmerkki"
+
+msgid "Other road sign"
+msgstr "Muu merkki"
 
 msgid "Code"
 msgstr "Koodi"

--- a/traffic_control/models/common.py
+++ b/traffic_control/models/common.py
@@ -188,6 +188,22 @@ class TrafficControlDeviceTypeQuerySet(models.QuerySet):
         return self.filter(Q(target_model=None) | Q(target_model=target_model))
 
 
+TRAFFIC_SIGN_TYPE_MAP = {
+    "A": _("Warning sign"),
+    "B": _("Priority or give-way sign"),
+    "C": _("Prohibitory or restrictive sign"),
+    "D": _("Mandatory sign"),
+    "E": _("Regulatory sign"),
+    "F": _("Information sign"),
+    "G": _("Service sign"),
+    "H": _("Additional sign"),
+    "I": _("Other road sign"),
+}
+TRAFFIC_SIGN_TYPE_CHOICES = tuple(
+    (key, value) for key, value in TRAFFIC_SIGN_TYPE_MAP.items()
+)
+
+
 class TrafficControlDeviceType(models.Model):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
@@ -226,6 +242,10 @@ class TrafficControlDeviceType(models.Model):
 
     def __str__(self):
         return "%s - %s" % (self.code, self.description)
+
+    @property
+    def traffic_sign_type(self):
+        return TRAFFIC_SIGN_TYPE_MAP.get(self.code[0])
 
     def save(self, *args, **kwargs):
         if self.pk:

--- a/traffic_control/schema.py
+++ b/traffic_control/schema.py
@@ -18,6 +18,16 @@ file_uuid_parameter = openapi.Parameter(
 )
 
 
+class TrafficSignType(serializers.Serializer):
+    """
+    Serializer that is used to generate OpenAPI documentation for
+    TrafficControlDeviceType model's traffic_sign_type attribute.
+    """
+
+    code = serializers.CharField(read_only=True)
+    text = serializers.CharField(read_only=True)
+
+
 class FileUploadSchema(serializers.Serializer):
     """
     Serializer that is used to generate OpenAPI documentation for single file

--- a/traffic_control/serializers.py
+++ b/traffic_control/serializers.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from django.core.exceptions import ValidationError
+from drf_yasg.utils import swagger_serializer_method
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
@@ -40,6 +41,7 @@ from .models import (
     TrafficSignRealFile,
 )
 from .models.common import DeviceTypeTargetModel
+from .schema import TrafficSignType
 
 
 class TrafficLightPlanFileSerializer(serializers.ModelSerializer):
@@ -536,9 +538,20 @@ class PlanGeoJSONSerializer(PlanSerializer):
 class TrafficControlDeviceTypeSerializer(
     EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
+    traffic_sign_type = serializers.SerializerMethodField(
+        method_name="get_traffic_sign_type",
+    )
+
     class Meta:
         model = TrafficControlDeviceType
         exclude = ("legacy_code", "legacy_description")
+
+    @swagger_serializer_method(serializer_or_field=TrafficSignType)
+    def get_traffic_sign_type(self, obj):
+        value = obj.traffic_sign_type
+        if value:
+            return {"code": obj.code[0], "type": value}
+        return None
 
     def validate_target_model(
         self, value: Optional[DeviceTypeTargetModel]

--- a/traffic_control/tests/models/test_traffic_control_device_type.py
+++ b/traffic_control/tests/models/test_traffic_control_device_type.py
@@ -1,6 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 from django.utils.crypto import get_random_string
+from django.utils.translation import gettext_lazy as _
 
 from traffic_control.models.common import DeviceTypeTargetModel
 from traffic_control.tests.factories import (
@@ -175,3 +176,26 @@ def test__traffic_control_device_type__target_model__validate_multiple_invalid_r
 
         device_type.refresh_from_db()
         assert not device_type.target_model
+
+
+@pytest.mark.parametrize(
+    "code,expected_value",
+    (
+        ("A1", _("Warning sign")),
+        ("B1", _("Priority or give-way sign")),
+        ("C1", _("Prohibitory or restrictive sign")),
+        ("D1", _("Mandatory sign")),
+        ("E1", _("Regulatory sign")),
+        ("F1", _("Information sign")),
+        ("G1", _("Service sign")),
+        ("H1", _("Additional sign")),
+        ("I1", _("Other road sign")),
+        ("X", None),
+        ("123", None),
+    ),
+)
+@pytest.mark.django_db
+def test__traffic_control_device_type__traffic_sign_type(code, expected_value):
+    device_type = get_traffic_control_device_type(code=code)
+
+    assert device_type.traffic_sign_type == expected_value

--- a/traffic_control/tests/test_traffic_control_device_type_api.py
+++ b/traffic_control/tests/test_traffic_control_device_type_api.py
@@ -13,6 +13,7 @@ from traffic_control.tests.factories import (
     get_road_marking_real,
     get_signpost_plan,
     get_signpost_real,
+    get_traffic_control_device_type,
     get_traffic_light_plan,
     get_traffic_light_real,
     get_traffic_sign_plan,
@@ -206,6 +207,22 @@ class TrafficControlDeviceTypeTests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(TrafficControlDeviceType.objects.count(), 0)
+
+    def test__traffic_sign_type__filtering(self):
+        dt_1 = get_traffic_control_device_type(code="A1")
+        dt_2 = get_traffic_control_device_type(code="A2")
+        get_traffic_control_device_type(code="B1")
+        get_traffic_control_device_type(code="C1")
+
+        response = self.client.get(
+            reverse("v1:trafficcontroldevicetype-list"), data={"traffic_sign_type": "A"}
+        )
+
+        response_data = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_data["count"], 2)
+        self.assertEqual(response_data["results"][0]["id"], str(dt_1.pk))
+        self.assertEqual(response_data["results"][1]["id"], str(dt_2.pk))
 
     @staticmethod
     def __create_test_traffic_control_device_type():


### PR DESCRIPTION
Add `traffic_sign_type` property for `TrafficControlDeviceType` model
and expose it in API as object containing the type code and text
representation. This is done so the API endpoint results can be
filtered by the traffic sign type.

Refs LIIK-135