### PR TITLE
Validate target model change when update target model of an exisint device type

### DIFF
--- a/traffic_control/serializers.py
+++ b/traffic_control/serializers.py
@@ -556,10 +556,11 @@ class TrafficControlDeviceTypeSerializer(
     def validate_target_model(
         self, value: Optional[DeviceTypeTargetModel]
     ) -> Optional[DeviceTypeTargetModel]:
-        try:
-            self.instance.validate_change_target_model(value, raise_exception=True)
-        except ValidationError as error:
-            raise serializers.ValidationError(error.message)
+        if self.instance and self.instance.target_model != value:
+            try:
+                self.instance.validate_change_target_model(value, raise_exception=True)
+            except ValidationError as error:
+                raise serializers.ValidationError(error.message)
 
         return value
 

--- a/traffic_control/tests/test_traffic_control_device_type_api.py
+++ b/traffic_control/tests/test_traffic_control_device_type_api.py
@@ -105,6 +105,7 @@ class TrafficControlDeviceTypeTests(APITestCase):
         data = {
             "code": "L3",
             "description": "Suojatie",
+            "target_model": DeviceTypeTargetModel.ADDITIONAL_SIGN.value,
         }
         response = self.client.post(
             reverse("v1:trafficcontroldevicetype-list"), data, format="json"


### PR DESCRIPTION
Previously the validate_target_model method is validating the target model even
when creating new device types. This cause the method fail as the device type
instance does not exist when running the validation method.

Refs: LIIK-162