### PR TITLE
Allow users to authenticate to REST API with Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `traffic_sign_type` property for `TrafficControlDeviceType`
 - Added tests for Katajanokka importer
 - Add traffic sign type list filter to `TrafficControlDeviceTypeAdmin`
+- Allow users to authenticate to the REST API with Token
 
 ### Changed
 - Admin UI usability improvements

--- a/city-infrastructure-platform/settings.py
+++ b/city-infrastructure-platform/settings.py
@@ -138,6 +138,7 @@ DJANGO_APPS = [
 THIRD_PARTY_APPS = [
     "django_extensions",
     "rest_framework",
+    "rest_framework.authtoken",
     "corsheaders",
     "drf_yasg",
     "django_filters",
@@ -241,6 +242,7 @@ USE_X_FORWARDED_HOST = env("TRUST_X_FORWARDED_HOST")
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "helusers.oidc.ApiTokenAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],


### PR DESCRIPTION

<img width="1038" alt="admin-token-auth" src="https://user-images.githubusercontent.com/2784933/90595244-05470900-e1f5-11ea-877d-4e6130866321.png">

Enable standard DRF TokenAuthentication mechanism.
Tokens can be created for existing users through Django Admin UI.

Refs LIIK-171