### PR TITLE
Add Operational Area REST API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add traffic sign type list filter to `TrafficControlDeviceTypeAdmin`
 - Allow users to authenticate to the REST API with Token
 - Add a layer model and a map view to visualize data on the map
+- Add REST API endpoint for `OperationalArea`
 
 ### Changed
 - Admin UI usability improvements

--- a/city-infrastructure-platform/urls.py
+++ b/city-infrastructure-platform/urls.py
@@ -12,6 +12,7 @@ from traffic_control.views import (
     additional_sign as additional_sign_views,
     barrier as barrier_views,
     mount as mount_views,
+    operational_area as operational_area_views,
     plan as plan_views,
     road_marking as road_marking_views,
     signpost as signpost_views,
@@ -81,6 +82,9 @@ router.register(
 )
 router.register(
     "mount-types", mount_views.MountTypeViewSet,
+)
+router.register(
+    "operational-areas", operational_area_views.OperationalAreaViewSet,
 )
 schema_view = get_schema_view(
     openapi.Info(

--- a/traffic_control/serializers.py
+++ b/traffic_control/serializers.py
@@ -20,6 +20,7 @@ from .models import (
     MountReal,
     MountRealFile,
     MountType,
+    OperationalArea,
     Plan,
     PortalType,
     RoadMarkingPlan,
@@ -574,4 +575,12 @@ class PortalTypeSerializer(serializers.ModelSerializer):
 class MountTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = MountType
+        fields = "__all__"
+
+
+class OperationalAreaSerializer(serializers.ModelSerializer):
+    area = GeometryField()
+
+    class Meta:
+        model = OperationalArea
         fields = "__all__"

--- a/traffic_control/tests/test_operational_area_api.py
+++ b/traffic_control/tests/test_operational_area_api.py
@@ -1,0 +1,101 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from traffic_control.models import OperationalArea
+from traffic_control.tests.factories import get_operational_area, get_user
+from traffic_control.tests.test_base_api import test_polygon
+
+
+class OperationalAreaAPITestCase(APITestCase):
+    def setUp(self):
+        self.operational_area = get_operational_area()
+        self.user = get_user()
+        self.admin = get_user(admin=True)
+
+    def test_admin_list_operational_areas_ok(self):
+        url = reverse("v1:operationalarea-list")
+        self.client.force_login(self.admin)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_admin_retrieve_operational_area_ok(self):
+        url = reverse(
+            "v1:operationalarea-detail", kwargs={"pk": self.operational_area.id}
+        )
+        self.client.force_login(self.admin)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_admin_create_operational_area_created(self):
+        url = reverse("v1:operationalarea-list")
+        self.client.force_login(self.admin)
+        data = {"name": "TEST AREA", "area": test_polygon.ewkt}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(OperationalArea.objects.filter(name="TEST AREA").count(), 1)
+
+    def test_admin_update_operational_area_ok(self):
+        url = reverse(
+            "v1:operationalarea-detail", kwargs={"pk": self.operational_area.id}
+        )
+        self.client.force_login(self.admin)
+        data = {
+            "id": self.operational_area.id,
+            "name": "TEST AREA",
+            "area": test_polygon.ewkt,
+        }
+        response = self.client.put(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(OperationalArea.objects.filter(name="TEST AREA").count(), 1)
+
+    def test_admin_delete_operational_area_deleted(self):
+        url = reverse(
+            "v1:operationalarea-detail", kwargs={"pk": self.operational_area.id}
+        )
+        self.client.force_login(self.admin)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(OperationalArea.objects.count(), 0)
+
+    def test_user_list_operational_area_forbidden(self):
+        url = reverse("v1:operationalarea-list")
+        self.client.force_login(self.user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_retrieve_operational_area_forbidden(self):
+        url = reverse(
+            "v1:operationalarea-detail", kwargs={"pk": self.operational_area.id}
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_create_operational_area_forbidden(self):
+        url = reverse("v1:operationalarea-list")
+        self.client.force_login(self.user)
+        data = {"name": "TEST AREA", "area": test_polygon.ewkt}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_update_operational_area_forbidden(self):
+        url = reverse(
+            "v1:operationalarea-detail", kwargs={"pk": self.operational_area.id}
+        )
+        self.client.force_login(self.user)
+        data = {
+            "id": self.operational_area.id,
+            "name": "TEST AREA",
+            "area": test_polygon.ewkt,
+        }
+        response = self.client.put(url, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_delete_operational_area_forbidden(self):
+        url = reverse(
+            "v1:operationalarea-detail", kwargs={"pk": self.operational_area.id}
+        )
+        self.client.force_login(self.user)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/traffic_control/views/operational_area.py
+++ b/traffic_control/views/operational_area.py
@@ -1,0 +1,47 @@
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.permissions import IsAdminUser
+from rest_framework.viewsets import ModelViewSet
+
+from traffic_control.models import OperationalArea
+from traffic_control.serializers import OperationalAreaSerializer
+
+
+@method_decorator(
+    name="create",
+    decorator=swagger_auto_schema(operation_description="Create new Operational Area"),
+)
+@method_decorator(
+    name="list",
+    decorator=swagger_auto_schema(
+        operation_description="Retrieve all Operational Area"
+    ),
+)
+@method_decorator(
+    name="retrieve",
+    decorator=swagger_auto_schema(
+        operation_description="Retrieve single Operational Area"
+    ),
+)
+@method_decorator(
+    name="update",
+    decorator=swagger_auto_schema(
+        operation_description="Update single Operational Area"
+    ),
+)
+@method_decorator(
+    name="partial_update",
+    decorator=swagger_auto_schema(
+        operation_description="Partially update single Operational Area"
+    ),
+)
+@method_decorator(
+    name="destroy",
+    decorator=swagger_auto_schema(
+        operation_description="Delete single Operational Area"
+    ),
+)
+class OperationalAreaViewSet(ModelViewSet):
+    permission_classes = [IsAdminUser]
+    serializer_class = OperationalAreaSerializer
+    queryset = OperationalArea.objects.all()


### PR DESCRIPTION
Operational areas are used to restrict the access to features, thus
they are only accessible by admin users.

Refs: LIIK-119