### PR TITLE
Show links to admin change view when clicking features on map view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow users to authenticate to the REST API with Token
 - Add a layer model and a map view to visualize data on the map
 - Add REST API endpoint for `OperationalArea`
+- Show admin links when clicking features on map view
 
 ### Changed
 - Admin UI usability improvements

--- a/map/static/map/app.js
+++ b/map/static/map/app.js
@@ -5,24 +5,84 @@
   function MapView(target, mapConfig) {
     this.mapConfig = mapConfig;
     this.map = this.createMap(target);
+    this.featureInfoPopup = this.createFeatureInfoPopup();
+    this.map.addOverlay(this.featureInfoPopup);
   }
 
   MapView.prototype.createMap = function(target) {
     const projection = this.getProjection();
     const helsinkiCoords = [25499052.02, 6675851.38];
     const resolutions = [256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125, 0.0625];
-    return new ol.Map({
+    const basemapLayerGroup = this.getBasemapLayerGroup()
+    const overlayLayerGroup = this.getOverlayLayerGroup()
+    const view = new ol.View({
+      projection: projection,
+      center: helsinkiCoords,
+      zoom: 5,
+      resolutions: resolutions,
+      extent: projection.getExtent()
+    });
+    const map = new ol.Map({
       target: target,
       controls: this.getControls(),
-      layers: [this.getBasemapLayerGroup(), this.getOverlayLayerGroup()],
-      view: new ol.View({
-        projection: projection,
-        center: helsinkiCoords,
-        zoom: 5,
-        resolutions: resolutions,
-        extent: projection.getExtent()
-      })
+      layers: [basemapLayerGroup, overlayLayerGroup],
+      view: view
     });
+
+    map.on("singleclick", (event) => {
+      const viewResolution = view.getResolution();
+      const visibleLayers = overlayLayerGroup.getLayers().getArray().filter(layer => layer.getVisible())
+      if (visibleLayers.length > 0) {
+        const layerNames = visibleLayers.map(layer => layer.getSource().getParams().LAYERS);
+        const url = visibleLayers[0].getSource().getFeatureInfoUrl(
+          event.coordinate,
+          viewResolution,
+          projection,
+          {
+            INFO_FORMAT: "application/json",
+            LAYERS: layerNames.join(","),
+            FEATURE_COUNT: 10
+          }
+        );
+
+        if (url) {
+          fetch(url).then(response => response.text()).then(responseText => {
+            const data = JSON.parse(responseText);
+            const features = data["features"];
+            if (features.length > 0) {
+              this.showFeatureInfo(event.coordinate, features);
+            }
+          });
+        }
+      }
+    });
+
+    return map;
+  };
+
+  MapView.prototype.createFeatureInfoPopup = function() {
+    return new ol.Overlay({
+      element: document.getElementById("feature-info-popup"),
+      autoPan: true,
+      autoPanAnimation: {
+        duration: 250,
+      }
+    });
+  };
+
+  MapView.prototype.closeFeatureInfo = function() {
+    this.featureInfoPopup.setPosition(undefined);
+  };
+
+  MapView.prototype.showFeatureInfo = function(coordinate, features) {
+    const featureList = features.map(feature => {
+      const [featureType, featureId] = feature["id"].split(".");
+      const url = `/admin/traffic_control/${featureType.replace(/_/g, "")}/${featureId}/change`;
+      return `<div>${featureType}: <a target="_blank" href="${url}">${featureId}</a></div>`;
+    });
+    const featureListElem = document.getElementById("feature-list");
+    featureListElem.innerHTML = featureList.join("\n");
+    this.featureInfoPopup.setPosition(coordinate);
   };
 
   MapView.prototype.getBasemapLayerGroup = function() {

--- a/map/static/map/style.css
+++ b/map/static/map/style.css
@@ -30,5 +30,52 @@ html, body {
 }
 
 .mouse-position, .ol-scale-line {
-    background-color: rgba(0,60,136,.5);
+    background-color: rgba(0, 60, 136, .5);
+}
+
+.ol-popup {
+    position: absolute;
+    background-color: white;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+    padding: 15px;
+    border-radius: 10px;
+    border: 1px solid #cccccc;
+    bottom: 12px;
+    left: -50px;
+    min-width: 400px;
+    z-index: 100;
+}
+
+.ol-popup:after, .ol-popup:before {
+    top: 100%;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+}
+
+.ol-popup:after {
+    border-top-color: white;
+    border-width: 10px;
+    left: 48px;
+    margin-left: -10px;
+}
+
+.ol-popup:before {
+    border-top-color: #cccccc;
+    border-width: 11px;
+    left: 48px;
+    margin-left: -11px;
+}
+
+.ol-popup-closer {
+    text-decoration: none;
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    border: none;
+    outline: none;
+    background-color: white;
 }

--- a/map/templates/map/map_view.html
+++ b/map/templates/map/map_view.html
@@ -15,6 +15,10 @@
 </head>
 <body>
 <div id="map"></div>
+<div id="feature-info-popup" class="ol-popup">
+    <button onclick="mapView.closeFeatureInfo()" class="ol-popup-closer">✖</button>
+    <div id="feature-list" class="feature-list"></div>
+</div>
 <script>
     const mapView = new MapView("map", {{ map_config | safe }});
 </script>


### PR DESCRIPTION
The features information are fetched via WMS GetFeatureInfo requests.

For simplicity purposes, we made following assumptions to the format
of WMS GetFeatureInfo responses for all layers (base on current
GeoServer setup):

- All layers are traffic control layers
- The "id" field of features are in the format of "<feature_type>.<instance_id>"
- The <feature_type> must match the model contenttype name after removing all "_"

Refs: LIIK-78

![map-view-admin-link](https://user-images.githubusercontent.com/1997039/91270217-f6c29980-e780-11ea-88f7-7572006a4a65.gif)
