### PR TITLE
Use raw_id_fields in admin for plan and real relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed a bug that creating `TrafficControlDeviceType` crashes when target model is specified
+- Traffic control model admin performance issues caused by multiple foreign key choices
 
 ## [1.0.0] - 2020-07-07
 

--- a/traffic_control/admin/additional_sign.py
+++ b/traffic_control/admin/additional_sign.py
@@ -113,6 +113,7 @@ class AdditionalSignPlanAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("parent", "plan", "mount_plan")
     list_filter = SoftDeleteAdminMixin.list_filter + ["owner"]
     ordering = ("-created_at",)
     inlines = (AdditionalSignContentPlanInline,)
@@ -255,6 +256,7 @@ class AdditionalSignRealAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("parent", "additional_sign_plan", "mount_real")
     ordering = ("-created_at",)
     list_filter = SoftDeleteAdminMixin.list_filter + [
         ("lifecycle", EnumFieldListFilter),

--- a/traffic_control/admin/barrier.py
+++ b/traffic_control/admin/barrier.py
@@ -90,6 +90,7 @@ class BarrierPlanAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("plan",)
     ordering = ("-created_at",)
     inlines = (BarrierPlanFileInline,)
 
@@ -172,5 +173,6 @@ class BarrierRealAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("barrier_plan",)
     ordering = ("-created_at",)
     inlines = (BarrierRealFileInline,)

--- a/traffic_control/admin/mount.py
+++ b/traffic_control/admin/mount.py
@@ -91,6 +91,7 @@ class MountPlanAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("plan",)
     ordering = ("-created_at",)
     inlines = (MountPlanFileInline,)
 
@@ -164,6 +165,7 @@ class MountRealAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("mount_plan",)
     ordering = ("-created_at",)
     inlines = (MountRealFileInline, OrderedTrafficSignRealInline)
 

--- a/traffic_control/admin/road_marking.py
+++ b/traffic_control/admin/road_marking.py
@@ -114,6 +114,7 @@ class RoadMarkingPlanAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("plan", "traffic_sign_plan")
     ordering = ("-created_at",)
     inlines = (RoadMarkingPlanFileInline,)
 
@@ -214,5 +215,6 @@ class RoadMarkingRealAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("road_marking_plan", "traffic_sign_real")
     ordering = ("-created_at",)
     inlines = (RoadMarkingRealFileInline,)

--- a/traffic_control/admin/signpost.py
+++ b/traffic_control/admin/signpost.py
@@ -97,6 +97,7 @@ class SignpostPlanAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("parent", "plan", "mount_plan")
     ordering = ("-created_at",)
     inlines = (SignpostPlanFileInline,)
 
@@ -196,5 +197,6 @@ class SignpostRealAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("parent", "signpost_plan", "mount_real")
     ordering = ("-created_at",)
     inline = (SignpostRealFileInline,)

--- a/traffic_control/admin/traffic_light.py
+++ b/traffic_control/admin/traffic_light.py
@@ -98,6 +98,7 @@ class TrafficLightPlanAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("plan", "mount_plan")
     ordering = ("-created_at",)
     inlines = (TrafficLightPlanFileInline,)
 
@@ -180,5 +181,6 @@ class TrafficLightRealAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("traffic_light_plan", "mount_real")
     ordering = ("-created_at",)
     inlines = (TrafficLightRealFileInline,)

--- a/traffic_control/admin/traffic_sign.py
+++ b/traffic_control/admin/traffic_sign.py
@@ -145,6 +145,7 @@ class TrafficSignPlanAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("plan", "mount_plan")
     ordering = ("-created_at",)
     inlines = (TrafficSignPlanFileInline,)
 
@@ -296,6 +297,7 @@ class TrafficSignRealAdmin(
         "created_by",
         "updated_by",
     )
+    raw_id_fields = ("traffic_sign_plan", "mount_real")
     ordering = ("-created_at",)
     list_filter = SoftDeleteAdminMixin.list_filter + [
         ("lifecycle", EnumFieldListFilter),


### PR DESCRIPTION
Admin add/change views get really slow when there's a foreign key
relation with lot of choices (20k+ in this case). To remedy this change
admin to use raw_id_fields for any relation to any traffic control real
or plan models since all of those will most likely end up having so many
choices that it will affect the usability considerably.

Refs LIIK-177