### PR TITLE
Add a management command to import parking areas from Helsinki City WFS layer

### DIFF
--- a/traffic_control/management/commands/import_parking_areas_hki_wfs.py
+++ b/traffic_control/management/commands/import_parking_areas_hki_wfs.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from urllib.request import urlretrieve
+
+from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.geos import MultiPolygon
+from django.core.management import BaseCommand
+
+from traffic_control.models import Owner
+from traffic_control.models.affect_area import ParkingArea, ParkingAreaCategory
+
+SOURCE_NAME = "pysäköintialue"
+WFS_SOURCE_URL = "https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
+SOURCE_LAYER = "Pysakointipaikat_alue"
+DATE_FORMAT = "%Y-%m-%d"
+OWNER_NAME = "City of Helsinki"
+
+
+def parse_date(date_str):
+    return datetime.strptime(date_str, DATE_FORMAT).date()
+
+
+def parse_str_value(str_value):
+    # string value can be None from WFS data, replace them with emtpy string
+    return str_value or ""
+
+
+class Command(BaseCommand):
+    help = "Import parking areas from Helsinki WFS"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.categories = {
+            category.id: category for category in ParkingAreaCategory.objects.all()
+        }
+
+    def handle(self, *args, **options):
+        self.stdout.write("Importing parking areas from Helsinki WFS ...")
+        url = f"{WFS_SOURCE_URL}?service=wfs&version=2.0.0&request=GetFeature&typeNames={SOURCE_LAYER}"
+        filename, _ = urlretrieve(url)
+        ds = DataSource(filename)
+        count = 0
+        owner = Owner.objects.get(name_en="City of Helsinki")
+        for feature in ds[0]:
+            category_id = feature["luokka"].value
+            category_name = parse_str_value(feature["luokka_nimi"].value)
+            category = self.get_parking_area_category(category_id, category_name)
+            geometry = feature.geom.geos
+            if geometry.geom_type == "Polygon":
+                # the WFS layer has mixed geometries (Polygon & MultiPolygon)
+                geometry = MultiPolygon([geometry])
+            ParkingArea.objects.update_or_create(
+                source_name=SOURCE_NAME,
+                source_id=feature["id"].value,
+                defaults={
+                    "category": category,
+                    "area_type": parse_str_value(feature["tyyppi"].value),
+                    "season": parse_str_value(feature["kausi"].value),
+                    "resident_parking_id": parse_str_value(
+                        feature["asukaspysakointitunnus"].value
+                    ),
+                    "place_position": parse_str_value(feature["paikan_asento"].value),
+                    "validity": parse_str_value(feature["voimassaolo"].value),
+                    "duration": parse_str_value(feature["kesto"].value),
+                    "surface_area": feature["pinta_ala"].value,
+                    "parking_slots": feature["paikat_ala"].value,
+                    "additional_info": parse_str_value(feature["lisatieto"].value),
+                    "stopping_prohibited": parse_str_value(
+                        feature["pysayttamiskielto"].value
+                    ),
+                    "updated_at": parse_date(
+                        feature["paivitetty_tietopalveluun"].value
+                    ),
+                    "owner": owner,
+                    "location": geometry,
+                },
+            )
+            count += 1
+        self.stdout.write(f"{count} parking areas are imported.")
+
+    def get_parking_area_category(self, category_id, category_name):
+        if category_id not in self.categories:
+            category = ParkingAreaCategory.objects.create(
+                id=category_id, name=category_name
+            )
+            self.categories[category_id] = category
+        return self.categories[category_id]

--- a/traffic_control/tests/management/commands/test_import_parking_areas_hki_wfs.py
+++ b/traffic_control/tests/management/commands/test_import_parking_areas_hki_wfs.py
@@ -1,0 +1,99 @@
+from collections import UserDict
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.gis.gdal import SpatialReference
+from django.core.management import call_command
+from django.test import TestCase
+
+from traffic_control.models.affect_area import ParkingArea, ParkingAreaCategory
+from traffic_control.tests.test_base_api import test_multi_polygon
+
+
+class MockAttribute:
+    def __init__(self, value):
+        self.value = value
+
+
+class MockFeature(UserDict):
+    def __init__(self, data, ogr_geom):
+        super().__init__(data)
+        self.geom = ogr_geom
+
+
+MOCK_FEATURE_1 = MockFeature(
+    {
+        "id": MockAttribute(1),
+        "luokka": MockAttribute(100),
+        "luokka_nimi": MockAttribute("category 1"),
+        "tyyppi": MockAttribute("type 1"),
+        "kausi": MockAttribute("summer"),
+        "asukaspysakointitunnus": MockAttribute("P"),
+        "paikan_asento": MockAttribute("facing street"),
+        "voimassaolo": MockAttribute("valid"),
+        "kesto": MockAttribute("4h"),
+        "pinta_ala": MockAttribute(120),
+        "paikat_ala": MockAttribute(20),
+        "lisatieto": MockAttribute("test description"),
+        "pysayttamiskielto": MockAttribute("stopping not allowed"),
+        "paivitetty_tietopalveluun": MockAttribute("2020-10-01"),
+        "datanomistaja": MockAttribute("dummy"),
+    },
+    test_multi_polygon.ogr,
+)
+
+MOCK_FEATURE_2 = MockFeature(
+    {
+        "id": MockAttribute(2),
+        "luokka": MockAttribute(100),
+        "luokka_nimi": MockAttribute("category 1"),
+        "tyyppi": MockAttribute("type 1"),
+        "kausi": MockAttribute("summer"),
+        "asukaspysakointitunnus": MockAttribute("P"),
+        "paikan_asento": MockAttribute("facing street"),
+        "voimassaolo": MockAttribute("valid"),
+        "kesto": MockAttribute("4h"),
+        "pinta_ala": MockAttribute(120),
+        "paikat_ala": MockAttribute(20),
+        "lisatieto": MockAttribute("test description"),
+        "pysayttamiskielto": MockAttribute("stopping not allowed"),
+        "paivitetty_tietopalveluun": MockAttribute("2020-10-01"),
+        "datanomistaja": MockAttribute("dummy"),
+    },
+    test_multi_polygon.ogr,
+)
+
+
+class MockLayer:
+    def __init__(self):
+        self.srs = SpatialReference(settings.SRID)
+        self.mock_features = [
+            MOCK_FEATURE_1,
+            MOCK_FEATURE_2,
+        ]
+
+    def __iter__(self):
+        yield from self.mock_features
+
+    def __len__(self):
+        return len(self.mock_features)
+
+
+class MockDataSource:
+    def __init__(self, ds_input):
+        pass
+
+    def __getitem__(self, index):
+        return MockLayer()
+
+
+class ImportParkingAreaTestCase(TestCase):
+    @patch("urllib.request.urlretrieve", return_value=("dummy-file", {}))
+    @patch(
+        "traffic_control.management.commands.import_parking_areas_hki_wfs.DataSource",
+        MockDataSource,
+    )
+    def test_importer_created_operational_areas(self, mock_urlretrieve):
+        call_command("import_parking_areas_hki_wfs")
+        self.assertEqual(ParkingArea.objects.count(), 2)
+        self.assertEqual(ParkingAreaCategory.objects.count(), 1)

--- a/traffic_control/tests/management/commands/test_import_parking_areas_hki_wfs.py
+++ b/traffic_control/tests/management/commands/test_import_parking_areas_hki_wfs.py
@@ -1,25 +1,15 @@
-from collections import UserDict
 from unittest.mock import patch
 
-from django.conf import settings
-from django.contrib.gis.gdal import SpatialReference
 from django.core.management import call_command
 from django.test import TestCase
 
 from traffic_control.models.affect_area import ParkingArea, ParkingAreaCategory
+from traffic_control.tests.management.commands.utils import (
+    create_mock_data_source,
+    MockAttribute,
+    MockFeature,
+)
 from traffic_control.tests.test_base_api import test_multi_polygon
-
-
-class MockAttribute:
-    def __init__(self, value):
-        self.value = value
-
-
-class MockFeature(UserDict):
-    def __init__(self, data, ogr_geom):
-        super().__init__(data)
-        self.geom = ogr_geom
-
 
 MOCK_FEATURE_1 = MockFeature(
     {
@@ -64,36 +54,13 @@ MOCK_FEATURE_2 = MockFeature(
 )
 
 
-class MockLayer:
-    def __init__(self):
-        self.srs = SpatialReference(settings.SRID)
-        self.mock_features = [
-            MOCK_FEATURE_1,
-            MOCK_FEATURE_2,
-        ]
-
-    def __iter__(self):
-        yield from self.mock_features
-
-    def __len__(self):
-        return len(self.mock_features)
-
-
-class MockDataSource:
-    def __init__(self, ds_input):
-        pass
-
-    def __getitem__(self, index):
-        return MockLayer()
-
-
 class ImportParkingAreaTestCase(TestCase):
     @patch("urllib.request.urlretrieve", return_value=("dummy-file", {}))
     @patch(
         "traffic_control.management.commands.import_parking_areas_hki_wfs.DataSource",
-        MockDataSource,
+        create_mock_data_source([MOCK_FEATURE_1, MOCK_FEATURE_2]),
     )
-    def test_importer_created_operational_areas(self, mock_urlretrieve):
+    def test_importer_created_parking_areas(self, mock_urlretrieve):
         call_command("import_parking_areas_hki_wfs")
         self.assertEqual(ParkingArea.objects.count(), 2)
         self.assertEqual(ParkingAreaCategory.objects.count(), 1)

--- a/traffic_control/tests/management/commands/utils.py
+++ b/traffic_control/tests/management/commands/utils.py
@@ -1,4 +1,8 @@
+from collections import UserDict
 from unittest.mock import mock_open as _mock_open
+
+from django.conf import settings
+from django.contrib.gis.gdal import SpatialReference
 
 
 def mock_open(mock=None, read_data=""):
@@ -9,3 +13,47 @@ def mock_open(mock=None, read_data=""):
     m.return_value.__iter__ = lambda f: f
     m.return_value.__next__ = lambda f: next(iter(f.readline, ""))
     return m
+
+
+class MockAttribute:
+    def __init__(self, value):
+        self.value = value
+
+
+class MockFeature(UserDict):
+    def __init__(self, data, ogr_geom):
+        super().__init__(data)
+        self.geom = ogr_geom
+
+
+def create_mock_data_source(features):
+    """
+    Create a mock data source class
+
+    The mock data source will create a single layer
+    in the data source, and the layer will include
+    features provided in function arguments
+
+    :param features: Features to be included in the data source layer
+    :return:
+    """
+
+    class MockLayer:
+        def __init__(self):
+            self.srs = SpatialReference(settings.SRID)
+            self.mock_features = features
+
+        def __iter__(self):
+            yield from self.mock_features
+
+        def __len__(self):
+            return len(self.mock_features)
+
+    class MockDataSource:
+        def __init__(self, ds_input):
+            pass
+
+        def __getitem__(self, index):
+            return MockLayer()
+
+    return MockDataSource


### PR DESCRIPTION
This PR adds a management command that can import parking areas from `Pysakointipaikat_alue` WFS layer . The command is idempotent and can be used to update parking areas if there're updates on WFS layer. However, it does not remove parking areas from database if there are parking areas removed from WFS layer.

It should be noted that there are mixed geometries (Polygon & MultiPolygon) in `Pysakointipaikat_alue` WFS layer. We convert all polygons to multi-polygons so that we can have a single geometry type for Parking areas.

This PR also refactor the DataSource mocking that is used both in `test_import_parking_areas_hki_wfs` and `test_import_operational_areas_hki_wfs` to remove code duplication.

Refs: LIIK-193