### PR TITLE
Add localization to map view

### DIFF
--- a/map-view/package.json
+++ b/map-view/package.json
@@ -13,10 +13,13 @@
     "@types/ol": "^6.3.1",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
+    "i18next": "^19.8.3",
+    "i18next-browser-languagedetector": "^6.0.1",
     "ol": "^6.4.3",
     "prettier": "^2.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-i18next": "^11.7.3",
     "react-scripts": "3.4.3",
     "typescript": "~3.7.2"
   },

--- a/map-view/src/components/FeatureInfo.tsx
+++ b/map-view/src/components/FeatureInfo.tsx
@@ -10,6 +10,7 @@ import NavigateNext from "@material-ui/icons/NavigateNext";
 import React from "react";
 import { APIBaseUrl } from "../consts";
 import { Feature } from "../models";
+import { withTranslation, WithTranslation } from "react-i18next";
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -33,7 +34,7 @@ const styles = (theme: Theme) =>
     },
   });
 
-interface FeatureInfoProps extends WithStyles<typeof styles> {
+interface FeatureInfoProps extends WithStyles<typeof styles>, WithTranslation {
   features: Feature[];
   onClose: () => void;
 }
@@ -58,7 +59,7 @@ class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoStates> {
   }
 
   render() {
-    const { features, onClose, classes } = this.props;
+    const { features, onClose, classes, t } = this.props;
     const { featureIndex } = this.state;
     const feature = features[featureIndex];
     const fid = feature["id"];
@@ -80,9 +81,9 @@ class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoStates> {
           </Typography>
         </CardContent>
         <CardActions>
-          <Button onClick={onClose}>Close</Button>
+          <Button onClick={onClose}>{t("close")}</Button>
           <Button color="primary" target="_blank" href={this.getAdminLink(feature)}>
-            Edit
+            {t("edit")}
           </Button>
           <div className={classes.spacer}></div>
           <Typography color="textSecondary">
@@ -108,4 +109,4 @@ class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoStates> {
   }
 }
 
-export default withStyles(styles)(FeatureInfo);
+export default withTranslation()(withStyles(styles)(FeatureInfo));

--- a/map-view/src/i18n.ts
+++ b/map-view/src/i18n.ts
@@ -1,0 +1,25 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import en from "./locale/en.json";
+import fi from "./locale/fi.json";
+
+i18n
+  .use(initReactI18next)
+  .use(LanguageDetector)
+  .init({
+    resources: {
+      en,
+      fi,
+    },
+    detection: {
+      order: ["path"],
+      lookupFromPathIndex: 0,
+    },
+    fallbackLng: "en",
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/map-view/src/index.tsx
+++ b/map-view/src/index.tsx
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
 
+import "./i18n"; // needs to be bundled
+
 ReactDOM.render(
   <React.StrictMode>
     <App />

--- a/map-view/src/locale/en.json
+++ b/map-view/src/locale/en.json
@@ -1,0 +1,6 @@
+{
+  "translation": {
+    "edit": "edit",
+    "close": "close"
+  }
+}

--- a/map-view/src/locale/fi.json
+++ b/map-view/src/locale/fi.json
@@ -1,0 +1,6 @@
+{
+  "translation": {
+    "edit": "muokkaa",
+    "close": "sulje"
+  }
+}

--- a/map-view/yarn.lock
+++ b/map-view/yarn.lock
@@ -995,6 +995,12 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -4711,6 +4717,12 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
+html-parse-stringify2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz#dc5670b7292ca158b7bc916c9a6735ac8872834a"
+  dependencies:
+    void-elements "^2.0.1"
+
 html-webpack-plugin@4.0.0-beta.11:
   version "4.0.0-beta.11"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz#3059a69144b5aecef97708196ca32f9e68677715"
@@ -4802,6 +4814,18 @@ https-browserify@^1.0.0:
 hyphenate-style-name@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+
+i18next-browser-languagedetector@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.0.1.tgz#83654bc87302be2a6a5a75146ffea97b4ca268cf"
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+
+i18next@^19.8.3:
+  version "19.8.3"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.3.tgz#10df7222db8c23389b13bceb9ba67a5e20a0241e"
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -7869,6 +7893,13 @@ react-error-overlay@^6.0.7:
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
 
+react-i18next@^11.7.3:
+  version "11.7.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.7.3.tgz#256461c46baf5b3208c3c6860ca4e569fc7ed053"
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    html-parse-stringify2 "2.0.1"
+
 react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -9408,6 +9439,10 @@ verror@1.10.0:
 vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
+
+void-elements@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR introduced localizations to the map view using i18next and react-i18next. The active language are detected from the url path. And the translations are stored in `map-view/src/locale/` folder.

Refs: LIIK-202

![image](https://user-images.githubusercontent.com/1997039/97450067-fc805b00-193a-11eb-8936-069ed49939f2.png)
