### PR TITLE
Set Plan linked_objects read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve fields naming in Plan API endpoint to make it more understandable
 - Remove `decision_date` and `decision_id` from traffic control plan models
 - Improve admin map view feature info window to include more fields
+- Set `Plan` `linked_objects` as read-only
 
 ## [1.2.0] - 2020-09-29
 

--- a/traffic_control/serializers/plan.py
+++ b/traffic_control/serializers/plan.py
@@ -1,60 +1,51 @@
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
 
-from ..models import (
-    AdditionalSignPlan,
-    BarrierPlan,
-    MountPlan,
-    Plan,
-    RoadMarkingPlan,
-    SignpostPlan,
-    TrafficLightPlan,
-    TrafficSignPlan,
-)
+from ..models import Plan
 
 
 class PlanRelationSerializer(serializers.ModelSerializer):
     barrier_plan_ids = serializers.PrimaryKeyRelatedField(
         source="barrier_plans",
         many=True,
-        queryset=BarrierPlan.objects.active(),
         required=False,
+        read_only=True,
     )
     mount_plan_ids = serializers.PrimaryKeyRelatedField(
         source="mount_plans",
         many=True,
-        queryset=MountPlan.objects.active(),
         required=False,
+        read_only=True,
     )
     road_marking_plan_ids = serializers.PrimaryKeyRelatedField(
         source="road_marking_plans",
         many=True,
-        queryset=RoadMarkingPlan.objects.active(),
         required=False,
+        read_only=True,
     )
     signpost_plan_ids = serializers.PrimaryKeyRelatedField(
         source="signpost_plans",
         many=True,
-        queryset=SignpostPlan.objects.active(),
         required=False,
+        read_only=True,
     )
     traffic_light_plan_ids = serializers.PrimaryKeyRelatedField(
         source="traffic_light_plans",
         many=True,
-        queryset=TrafficLightPlan.objects.active(),
         required=False,
+        read_only=True,
     )
     traffic_sign_plan_ids = serializers.PrimaryKeyRelatedField(
         source="traffic_sign_plans",
         many=True,
-        queryset=TrafficSignPlan.objects.active(),
         required=False,
+        read_only=True,
     )
     additional_sign_plan_ids = serializers.PrimaryKeyRelatedField(
         source="additional_sign_plans",
         many=True,
-        queryset=AdditionalSignPlan.objects.all(),
         required=False,
+        read_only=True,
     )
 
     class Meta:
@@ -71,7 +62,7 @@ class PlanRelationSerializer(serializers.ModelSerializer):
 
 
 class PlanSerializer(serializers.ModelSerializer):
-    linked_objects = PlanRelationSerializer(source="*", required=False)
+    linked_objects = PlanRelationSerializer(source="*", required=False, read_only=True)
 
     class Meta:
         model = Plan

--- a/traffic_control/tests/test_plan_api.py
+++ b/traffic_control/tests/test_plan_api.py
@@ -8,18 +8,7 @@ from rest_framework import status
 from rest_framework_gis.fields import GeoJsonDict
 
 from ..models import Plan
-from .factories import (
-    get_additional_sign_plan,
-    get_api_client,
-    get_barrier_plan,
-    get_mount_plan,
-    get_plan,
-    get_road_marking_plan,
-    get_signpost_plan,
-    get_traffic_light_plan,
-    get_traffic_sign_plan,
-    get_user,
-)
+from .factories import get_api_client, get_plan, get_user
 from .test_base_api import (
     test_multi_polygon,
     test_polygon,
@@ -78,13 +67,6 @@ def test_plan_create():
     user = get_user(admin=True)
     api_client = get_api_client(user=user)
     location = test_multi_polygon.ewkt
-    barrier_plan = get_barrier_plan()
-    mount_plan = get_mount_plan()
-    road_marking_plan = get_road_marking_plan()
-    signpost_plan = get_signpost_plan()
-    traffic_light_plan = get_traffic_light_plan()
-    traffic_sign_plan = get_traffic_sign_plan()
-    additional_sign_plan = get_additional_sign_plan()
 
     response = api_client.post(
         reverse("v1:plan-list"),
@@ -96,15 +78,6 @@ def test_plan_create():
             "decision_maker": "Decision Maker",
             "created_by": user.pk,
             "updated_by": user.pk,
-            "linked_objects": {
-                "barrier_plan_ids": [barrier_plan.pk],
-                "mount_plan_ids": [mount_plan.pk],
-                "road_marking_plan_ids": [road_marking_plan.pk],
-                "signpost_plan_ids": [signpost_plan.pk],
-                "traffic_light_plan_ids": [traffic_light_plan.pk],
-                "traffic_sign_plan_ids": [traffic_sign_plan.pk],
-                "additional_sign_plan_ids": [additional_sign_plan.pk],
-            },
         },
         format="json",
     )
@@ -119,14 +92,6 @@ def test_plan_create():
     assert plan.updated_by == user
     assert plan.planner == "Planner"
     assert plan.decision_maker == "Decision Maker"
-
-    assert barrier_plan in plan.barrier_plans.all()
-    assert mount_plan in plan.mount_plans.all()
-    assert road_marking_plan in plan.road_marking_plans.all()
-    assert signpost_plan in plan.signpost_plans.all()
-    assert traffic_light_plan in plan.traffic_light_plans.all()
-    assert traffic_sign_plan in plan.traffic_sign_plans.all()
-    assert additional_sign_plan in plan.additional_sign_plans.all()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Curently there's no easy way to configure different schema for read and write APIs, see details: https://github.com/axnsan12/drf-yasg/issues/70

We mark the linked_objects as read-only to make it more obvious in API docs.

Refs: LIIK-213