### PR TITLE
Improve feature info window to include more information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `decision_date` and `decision_id` from traffic control plan models
 - Improve admin map view feature info window to include more fields
 - Set `Plan` `linked_objects` as read-only
+- Improve feature info window to include more details and add localization to it
 
 ## [1.2.0] - 2020-09-29
 

--- a/map-view/src/common/Map.ts
+++ b/map-view/src/common/Map.ts
@@ -48,7 +48,7 @@ class Map {
         const layerNames = visibleLayers.map((layer) => (layer.getSource() as ImageWMS).getParams().LAYERS);
         const url = (visibleLayers[0].getSource() as ImageWMS).getFeatureInfoUrl(
           event.coordinate,
-          viewResolution,
+          viewResolution as number,
           projection,
           {
             INFO_FORMAT: "application/json",

--- a/map-view/src/components/FeatureInfo.test.tsx
+++ b/map-view/src/components/FeatureInfo.test.tsx
@@ -8,16 +8,19 @@ test("renders feature info", () => {
     {
       geometry: { type: "Point", coordinates: [1, 1] },
       geometry_name: "location",
-      id: "test_feature_class.20950c38-eb7e-11ea-adc1-0242ac120002",
+      id: "traffic_sign_real.20950c38-eb7e-11ea-adc1-0242ac120002",
       properties: {
         id: "fcdbbc6f-5903-4574-baa3-fef33a4b0621",
-        code: "CODE-1",
+        direction: "DIR-1",
         txt: "sample text",
+        value: 10,
+        device_type_code: "ABC",
+        device_type_description: "Sample description",
       },
       type: "Feature",
     },
   ];
   const { getByText } = render(<FeatureInfo features={mockFeatures} onClose={() => {}} />);
-  const featureClass = getByText(/Test Feature Class/i);
-  expect(featureClass).toBeInTheDocument();
+  const featureInfoTitle = getByText(/traffic_sign_real/i);
+  expect(featureInfoTitle).toBeInTheDocument();
 });

--- a/map-view/src/components/FeatureInfo.tsx
+++ b/map-view/src/components/FeatureInfo.tsx
@@ -64,20 +64,25 @@ class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoStates> {
     const feature = features[featureIndex];
     const fid = feature["id"];
     const featureType = fid.split(".")[0];
-    const { id, code, txt } = feature["properties"];
+    const { id, value, txt, direction, device_type_code, device_type_description } = feature["properties"];
+    const deviceTypeText = value
+      ? `${device_type_code} - ${device_type_description} (${value})`
+      : `${device_type_code} - ${device_type_description}`;
 
     return (
       <Card className={classes.root}>
         <CardContent>
           <Typography className={classes.title} variant="h5" component="h2">
-            {featureType.replace(/_/g, " ")}
+            {t(`featureInfoTitle.${featureType}`)}
           </Typography>
           <Typography className={classes.content} variant="body1" component="p">
-            <b>id</b>: {id}
+            <b>Id</b>: {id}
             <br />
-            <b>code</b>: {code}
+            <b>{t("Device type")}</b>: {deviceTypeText}
             <br />
-            <b>txt</b>: {txt}
+            <b>{t("Direction")}</b>: {direction}
+            <br />
+            <b>{t("Additional info")}</b>: {txt}
           </Typography>
         </CardContent>
         <CardActions>

--- a/map-view/src/locale/en.json
+++ b/map-view/src/locale/en.json
@@ -1,6 +1,15 @@
 {
   "translation": {
     "edit": "edit",
-    "close": "close"
+    "close": "close",
+    "featureInfoTitle": {
+      "traffic_sign_real": "Traffic Sign Real",
+      "traffic_sign_plan": "Traffic Sign Plan",
+      "additional_sign_real": "Additional Sign Real",
+      "additional_sign_plan": "Additional Sign Plan"
+    },
+    "Device type": "Device type",
+    "Direction": "Direction",
+    "Additional info": "Additional info"
   }
 }

--- a/map-view/src/locale/fi.json
+++ b/map-view/src/locale/fi.json
@@ -1,6 +1,15 @@
 {
   "translation": {
     "edit": "muokkaa",
-    "close": "sulje"
+    "close": "sulje",
+    "featureInfoTitle": {
+      "traffic_sign_real": "Liikennemerkkitoteuma",
+      "traffic_sign_plan": "Liikennemerkkisuunnitelma",
+      "additional_sign_real": "Lisäkilpitoteuma",
+      "additional_sign_plan": "Lisäkilpisuunnitelma"
+    },
+    "Device type": "Merkki",
+    "Direction": "Suunta",
+    "Additional info": "Lisätieto"
   }
 }

--- a/map-view/src/models.ts
+++ b/map-view/src/models.ts
@@ -17,7 +17,10 @@ export interface MapConfig {
 export interface FeatureProperties {
   id: string;
   txt: string;
-  code: string;
+  direction: string;
+  value: number;
+  device_type_code: string;
+  device_type_description: string;
 }
 
 export interface Feature {


### PR DESCRIPTION
Include more description to the feature in the feature info window (see screenshot), and add localization for field labels

The `value` are not displayed if the traffic sign real instance has an empty value for the `value` field

![image](https://user-images.githubusercontent.com/1997039/98519637-b4860000-2279-11eb-9821-6bb03edfd294.png)

Refs: LIIK-208