### PR TITLE
 Force 3d geometry when importing from HKI WFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Change TrafficSign and Signpost value field from IntegerField to DecimalField
 - Extract numeric values from text column when importing blom kartta traffic signs
+- Force 3d geometries when importing coverage areas and operational areas from HKI WFS
 
 ## [1.2.0] - 2020-09-29
 

--- a/traffic_control/management/commands/import_coverage_areas_hki_wfs.py
+++ b/traffic_control/management/commands/import_coverage_areas_hki_wfs.py
@@ -44,7 +44,9 @@ class Command(BaseCommand):
             category_id = feature["luokka"].value
             category_name = parse_str_value(feature["luokka_nimi"].value)
             category = self.get_coverage_area_category(category_id, category_name)
-            geometry = feature.geom.geos
+            gdal_geometry = feature.geom
+            gdal_geometry.coord_dim = 3  # force 3d coordinates
+            geometry = gdal_geometry.geos
             if geometry.geom_type == "Polygon":
                 # the WFS layer has mixed geometries (Polygon & MultiPolygon)
                 geometry = MultiPolygon([geometry])

--- a/traffic_control/management/commands/import_operational_areas_hki_wfs.py
+++ b/traffic_control/management/commands/import_operational_areas_hki_wfs.py
@@ -27,6 +27,8 @@ class Command(BaseCommand):
         count = 0
         for feature in ds[0]:
             if feature["tehtavakokonaisuus"].value == "KATU":
+                gdal_geometry = feature.geom
+                gdal_geometry.coord_dim = 3  # force 3d coordinates
                 start_date = parse_date(feature["alku_pvm"].value)
                 end_date = parse_date(feature["loppu_pvm"].value)
                 updated_date = parse_date(feature["paivitetty_tietopalveluun"].value)
@@ -43,7 +45,7 @@ class Command(BaseCommand):
                         "updated_date": updated_date,
                         "task": feature["tehtavakokonaisuus"].value,
                         "status": feature["status"].value,
-                        "location": feature.geom.geos,
+                        "location": gdal_geometry.geos,
                     },
                 )
                 count += 1


### PR DESCRIPTION
We have changed geometry fields to 3d, and source data
from HKI WFS are using 2d geometries. Force 3d coordinates
on those geometries before saving to database.

Refs: LIIK-222