### PR TITLE
Use value from related device type when saving traffic sign/signpost instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add direction indicator to traffic signs
 - Add management command to generate traffic sign plan icons
 - Add icon, value, unit and size fields to TrafficControlDeviceType model
+- Use device type value for traffic sign and signpost value field if not provided
 
 ### Changed
 - Change TrafficSign and Signpost value field from IntegerField to DecimalField

--- a/traffic_control/models/signpost.py
+++ b/traffic_control/models/signpost.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from enumfields import Enum, EnumField, EnumIntegerField
 
 from ..mixins.models import (
+    DecimalValueFromDeviceTypeMixin,
     SoftDeleteModel,
     SourceControlModel,
     UpdatePlanLocationMixin,
@@ -48,7 +49,11 @@ class LocationSpecifier(Enum):
 
 
 class SignpostPlan(
-    UpdatePlanLocationMixin, SourceControlModel, SoftDeleteModel, UserControlModel
+    DecimalValueFromDeviceTypeMixin,
+    UpdatePlanLocationMixin,
+    SourceControlModel,
+    SoftDeleteModel,
+    UserControlModel,
 ):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
@@ -208,7 +213,12 @@ class SignpostPlanFile(models.Model):
         return "%s" % self.file
 
 
-class SignpostReal(SourceControlModel, SoftDeleteModel, UserControlModel):
+class SignpostReal(
+    DecimalValueFromDeviceTypeMixin,
+    SourceControlModel,
+    SoftDeleteModel,
+    UserControlModel,
+):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )

--- a/traffic_control/models/traffic_sign.py
+++ b/traffic_control/models/traffic_sign.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from enumfields import Enum, EnumField, EnumIntegerField
 
 from ..mixins.models import (
+    DecimalValueFromDeviceTypeMixin,
     SoftDeleteModel,
     SourceControlModel,
     UpdatePlanLocationMixin,
@@ -63,7 +64,11 @@ class TrafficSignPlanQuerySet(SoftDeleteQuerySet):
 
 
 class TrafficSignPlan(
-    UpdatePlanLocationMixin, SourceControlModel, SoftDeleteModel, UserControlModel
+    DecimalValueFromDeviceTypeMixin,
+    UpdatePlanLocationMixin,
+    SourceControlModel,
+    SoftDeleteModel,
+    UserControlModel,
 ):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
@@ -234,7 +239,12 @@ class TrafficSignRealQuerySet(SoftDeleteQuerySet):
         additional_signs.soft_delete(user)
 
 
-class TrafficSignReal(SourceControlModel, SoftDeleteModel, UserControlModel):
+class TrafficSignReal(
+    DecimalValueFromDeviceTypeMixin,
+    SourceControlModel,
+    SoftDeleteModel,
+    UserControlModel,
+):
     id = models.UUIDField(
         primary_key=True, unique=True, editable=False, default=uuid.uuid4
     )

--- a/traffic_control/tests/factories.py
+++ b/traffic_control/tests/factories.py
@@ -271,9 +271,13 @@ def get_traffic_control_device_type(
     code: str = "A11",
     description: str = "Test",
     target_model: Optional[DeviceTypeTargetModel] = None,
+    value: str = "",
 ):
     return TrafficControlDeviceType.objects.get_or_create(
-        code=code, description=description, target_model=target_model
+        code=code,
+        description=description,
+        target_model=target_model,
+        value=value,
     )[0]
 
 

--- a/traffic_control/tests/test_signpost_api.py
+++ b/traffic_control/tests/test_signpost_api.py
@@ -1,4 +1,5 @@
 import datetime
+from decimal import Decimal
 
 import pytest
 from django.urls import reverse
@@ -76,7 +77,7 @@ def test__signpost_plan__valid_device_type(target_model):
     client = get_api_client(user=get_user(admin=True))
     signpost_plan = get_signpost_plan()
     device_type = get_traffic_control_device_type(
-        code="123", description="test", target_model=target_model
+        code="123", description="test", target_model=target_model, value="15"
     )
     data = {"device_type": device_type.id}
 
@@ -89,6 +90,7 @@ def test__signpost_plan__valid_device_type(target_model):
     signpost_plan.refresh_from_db()
     assert response.status_code == status.HTTP_200_OK
     assert signpost_plan.device_type == device_type
+    assert signpost_plan.value == Decimal("15")
 
 
 @pytest.mark.django_db
@@ -321,7 +323,7 @@ def test__signpost_real__valid_device_type(target_model):
     client = get_api_client(user=get_user(admin=True))
     signpost_real = get_signpost_real()
     device_type = get_traffic_control_device_type(
-        code="123", description="test", target_model=target_model
+        code="123", description="test", target_model=target_model, value="15"
     )
     data = {"device_type": device_type.id}
 
@@ -334,6 +336,7 @@ def test__signpost_real__valid_device_type(target_model):
     signpost_real.refresh_from_db()
     assert response.status_code == status.HTTP_200_OK
     assert signpost_real.device_type == device_type
+    assert signpost_real.value == Decimal("15")
 
 
 @pytest.mark.django_db

--- a/traffic_control/tests/test_traffic_sign_api.py
+++ b/traffic_control/tests/test_traffic_sign_api.py
@@ -1,4 +1,5 @@
 import datetime
+from decimal import Decimal
 
 import pytest
 from django.urls import reverse
@@ -75,7 +76,7 @@ def test__traffic_sign_plan__valid_device_type(target_model):
     client = get_api_client(user=get_user(admin=True))
     traffic_sign_plan = get_traffic_sign_plan()
     device_type = get_traffic_control_device_type(
-        code="123", description="test", target_model=target_model
+        code="123", description="test", target_model=target_model, value="12.5"
     )
     data = {"device_type": device_type.id}
 
@@ -88,6 +89,7 @@ def test__traffic_sign_plan__valid_device_type(target_model):
     traffic_sign_plan.refresh_from_db()
     assert response.status_code == status.HTTP_200_OK
     assert traffic_sign_plan.device_type == device_type
+    assert traffic_sign_plan.value == Decimal("12.5")
 
 
 @pytest.mark.django_db
@@ -321,7 +323,7 @@ def test__traffic_sign_real__valid_device_type(target_model):
     client = get_api_client(user=get_user(admin=True))
     traffic_sign_real = get_traffic_sign_real()
     device_type = get_traffic_control_device_type(
-        code="123", description="test", target_model=target_model
+        code="123", description="test", target_model=target_model, value="12.5"
     )
     data = {"device_type": device_type.id}
 
@@ -334,6 +336,7 @@ def test__traffic_sign_real__valid_device_type(target_model):
     traffic_sign_real.refresh_from_db()
     assert response.status_code == status.HTTP_200_OK
     assert traffic_sign_real.device_type == device_type
+    assert traffic_sign_real.value == Decimal("12.5")
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR adds a mixin class that will use the value from related device type when saving traffic signs and signpost instances. It will only assign the value when the value is empty and there's one available from related device type.

Refs: LIIK-216