### PR TITLE
Minimal GHA pipeline for running linters & pytest

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install PyPI dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: 3.7
     - name: Install required Ubuntu packages
       run: |
-        apt-get install gdal-bin
+        sudo apt-get install gdal-bin
     - name: Install PyPI dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,7 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
-name: City Infrastructure Platform
+name: City Infrastructure Platform tests
 
 on:
   push:
@@ -12,10 +9,12 @@ on:
 jobs:
   build:
 
+    # Ubuntu latests is Ubuntu 18.04 as of 2020/12
     runs-on: ubuntu-latest
 
     env:
       DEBUG: 1
+      # Disabled OIDC to allow for minimal test configuration
       OIDC_AUTHENTICATION_ENABLED: 0
       # Database for tests
       DATABASE_URL: postgis://postgres:postgres@localhost/city-infrastructure-platform
@@ -38,11 +37,11 @@ jobs:
         flake8
         black --check .
         isort . -c
-    - name: Test with pytest
+    - name: Run pytest code functionality tests
       run: |
         pytest -ra -vvv --cov=.
 
-    # Service containers to run with `container-job`
+    # Majority of the tests require database
     services:
       # Label used to access the service container
       postgres:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: City Infrastructure Platform
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install PyPI dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt requirements-dev.txt
+    - name: Run Python side code neatness tests
+      run: |
+        flake8
+        black --check .
+        isort . -c
+    - name: Test with pytest
+      run: |
+        pytest -ra -vvv --cov=.

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,7 @@ jobs:
       DEBUG: 1
       OIDC_AUTHENTICATION_ENABLED: 0
       # Database for tests
-      DATABASE_URL: postgis://postgres:postgres@postgres/city-infrastructure-platform
+      DATABASE_URL: postgis://postgres:postgres@localhost/city-infrastructure-platform
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,6 +17,8 @@ jobs:
     env:
       DEBUG: 1
       OIDC_AUTHENTICATION_ENABLED: 0
+      # Database for tests
+      DATABASE_URL: postgis://postgres:postgres@postgres/city-infrastructure-platform
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install PyPI dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt requirements-dev.txt
+        pip install -r requirements.txt -r requirements-dev.txt
     - name: Run Python side code neatness tests
       run: |
         flake8

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,6 +14,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      DEBUG: 1
+      OIDC_AUTHENTICATION_ENABLED: 0
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
@@ -32,3 +36,19 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -ra -vvv --cov=.
+
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,6 +24,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+    - name: Install required Ubuntu packages
+      run: |
+        apt get install gdal-bin
     - name: Install PyPI dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -47,7 +47,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres
+        image: postgis/postgis:10-2.5
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: 3.7
     - name: Install required Ubuntu packages
       run: |
-        apt get install gdal-bin
+        apt-get install gdal-bin
     - name: Install PyPI dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -57,3 +57,5 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 5432:5432


### PR DESCRIPTION
This is still missing Node-side on the tests. But let's have pytest running again.