### PR TITLE
Improve AdminTrafficSignIconSelectWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extract numeric values from text column when importing blom kartta traffic signs
 - Force 3d geometries when importing coverage areas and operational areas from HKI WFS
 
+### Fixed
+- Fix the styling of traffic sign icon widget so that the icon and select are in the same row
+
 ## [1.2.0] - 2020-09-29
 
 ### Added

--- a/traffic_control/forms.py
+++ b/traffic_control/forms.py
@@ -49,10 +49,10 @@ class AdminTrafficSignIconSelectWidget(Select):
 
     def get_icon_url(self, value):
         if not self.icon_url_mapping:
-            id_code_values = TrafficControlDeviceType.objects.values_list("id", "code")
+            id_icon_values = TrafficControlDeviceType.objects.values_list("id", "icon")
             self.icon_url_mapping = {
-                uuid: f"{settings.STATIC_URL}traffic_control/svg/traffic_sign_icons/{code}.svg"
-                for uuid, code in id_code_values
+                uuid: f"{settings.STATIC_URL}traffic_control/svg/traffic_sign_icons/{icon}"
+                for uuid, icon in id_icon_values
             }
         return self.icon_url_mapping.get(value, "")
 

--- a/traffic_control/forms.py
+++ b/traffic_control/forms.py
@@ -49,11 +49,13 @@ class AdminTrafficSignIconSelectWidget(Select):
 
     def get_icon_url(self, value):
         if not self.icon_url_mapping:
+            self.icon_url_mapping = {}
             id_icon_values = TrafficControlDeviceType.objects.values_list("id", "icon")
-            self.icon_url_mapping = {
-                uuid: f"{settings.STATIC_URL}traffic_control/svg/traffic_sign_icons/{icon}"
-                for uuid, icon in id_icon_values
-            }
+            for uuid, icon in id_icon_values:
+                if icon:
+                    icon_name, ext = icon.rsplit(".", maxsplit=1)
+                    icon_path = f"{settings.STATIC_URL}traffic_control/svg/traffic_sign_icons/{icon_name.upper()}.svg"
+                    self.icon_url_mapping[uuid] = icon_path
         return self.icon_url_mapping.get(value, "")
 
     def get_context(self, name, value, attrs):

--- a/traffic_control/static/traffic_control/css/traffic_sign_icon_select.css
+++ b/traffic_control/static/traffic_control/css/traffic_sign_icon_select.css
@@ -2,4 +2,5 @@
     height: 32px;
     width: auto;
     margin-right: 10px;
+    float: left;
 }

--- a/traffic_control/templates/admin/traffic_control/widgets/traffic_sign_icon_select.html
+++ b/traffic_control/templates/admin/traffic_control/widgets/traffic_sign_icon_select.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<img class="traffic-sign-icon" src="{% static icon_path %}" alt="Traffic sign icon" {% if not icon_path %}style="display: none;"{% endif %}>
+<img class="traffic-sign-icon" src="{{ icon_path }}" alt="Traffic sign icon" {% if not icon_path %}style="display: none;"{% endif %}>
 
 {# Default select widget template with added onchange attribute #}
 <select name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}


### PR DESCRIPTION
Previously the widget is using the `code` field to construct the icon path for traffic signs, which is not always correct. We now have a new icon field which specifies the right svg file to use for each device type. This PR changes to use the icon field to construct the icon path for the widget.

Since there's case inconsistency between the svg file names and the ones specified in icon field, we changed the svg file names to uppercase and also convert the icon field value into uppercase when using it in the code.

Refs: LIIK-219

![traffic-sign-icon](https://user-images.githubusercontent.com/1997039/102197340-adca5880-3ec9-11eb-8bcf-231ad83b41f3.gif)
