### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
         curl \
         nodejs \
         npm && \
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - && \
+    curl -sSL https://install.python-poetry.org | python - && \
     /root/.local/bin/poetry config virtualenvs.create false && \
     /root/.local/bin/poetry install --no-dev --no-interaction && \
     npm install -g yarn && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,9 @@ EXPOSE 8000
 FROM base AS build
 # ===================================
 COPY map-view/ /map-view/
-RUN cd /map-view && yarn install && yarn build
+RUN cd /map-view && \
+    yarn install --frozen-lockfile --no-cache --production && \
+    yarn build
 
 # ==============================
 FROM base AS production

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir /city-infrastructure-platform && \
     useradd -u 1000 -g appuser -ms /bin/bash appuser
 WORKDIR /city-infrastructure-platform
 
+COPY poetry.lock pyproject.toml /city-infrastructure-platform/
 
 RUN apt-get update && \
     mkdir -p /usr/share/man/man1/ /usr/share/man/man3/ /usr/share/man/man7/ && \
@@ -24,19 +25,15 @@ RUN apt-get update && \
         curl \
         nodejs \
         npm && \
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-
-ENV PATH = "${PATH}:/root/.poetry/bin"
-COPY poetry.lock pyproject.toml /city-infrastructure-platform/
-
-RUN poetry config virtualenvs.create false && \
-    poetry install --no-dev --no-interaction && \
+    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - && \
+    /root/.local/bin/poetry config virtualenvs.create false && \
+    /root/.local/bin/poetry install --no-dev --no-interaction && \
+    npm install -g yarn && \
     apt-get remove -y build-essential libpq-dev && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
     rm -rf /root/.cache/pip && \
-    npm install -g yarn && \
     npm cache clean --force
 
 COPY docker-entrypoint.sh /usr/local/bin
@@ -51,7 +48,7 @@ ENV APPLY_MIGRATIONS=1
 ENV COLLECT_STATIC=1
 ENV DEV_SERVER=1
 
-RUN poetry install
+RUN /root/.local/bin/poetry install
 COPY . /city-infrastructure-platform
 RUN chown -R appuser:appuser /city-infrastructure-platform
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,9 @@ RUN poetry config virtualenvs.create false && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
-    npm install -g yarn
+    rm -rf /root/.cache/pip && \
+    npm install -g yarn && \
+    npm cache clean --force
 
 COPY docker-entrypoint.sh /usr/local/bin
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,5 @@ yapf = "^0.32.0"
 
 
 [tool.black]
-exclude = "(migrations|node_modules)"
+extend-exclude = "migrations"
 line_length = 120


### PR DESCRIPTION
Do installations and possible deletions in a single RUN command. This way that layers don't get too large in size.

However, we could (should) make such multi-stage Dockerfile where the production image is built on top of slim Python. It should contain only build artifacts (and runtime libs), no build-time stuff at all.

Refs LIIK-298