### PR TITLE
FurnitureSignpost API aggregate fields

### DIFF
--- a/city_furniture/serializers/furniture_signpost.py
+++ b/city_furniture/serializers/furniture_signpost.py
@@ -25,6 +25,8 @@ class FurnitureSignpostPlanSerializer(EnumSupportSerializerMixin, serializers.Mo
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=CityFurnitureDeviceType.objects.for_target_model(CityFurnitureDeviceTypeTargetModel.FURNITURE_SIGNPOST)
     )
+    target_name = serializers.CharField(read_only=True, source="target.name")
+    device_type_description = serializers.CharField(read_only=True, source="device_type.description")
 
     class Meta:
         model = FurnitureSignpostPlan
@@ -81,6 +83,8 @@ class FurnitureSignpostRealSerializer(EnumSupportSerializerMixin, serializers.Mo
         queryset=CityFurnitureDeviceType.objects.for_target_model(CityFurnitureDeviceTypeTargetModel.FURNITURE_SIGNPOST)
     )
     operations = FurnitureSignpostRealOperationSerializer(many=True, required=False, read_only=True)
+    target_name = serializers.CharField(read_only=True, source="target.name_fi")
+    device_type_description = serializers.CharField(read_only=True, source="device_type.description")
 
     class Meta:
         model = FurnitureSignpostReal

--- a/city_furniture/views/furniture_signpost.py
+++ b/city_furniture/views/furniture_signpost.py
@@ -148,7 +148,7 @@ class FurnitureSignpostRealViewSet(TrafficControlViewSet, FileUploadViews):
     filterset_class = FurnitureSignpostRealFilterSet
     file_queryset = FurnitureSignpostRealFile.objects.all()
     file_serializer = FurnitureSignpostRealFileSerializer
-    file_relation = "furniture_sigpost_real"
+    file_relation = "furniture_signpost_real"
 
     @swagger_auto_schema(
         method="post",


### PR DESCRIPTION
Include `target_name` and `device_type_description` in the API endpoint, to remove the need to fetch them from another endpoint.

refs. LIIK-300