### PR TITLE
Importer and CityFurniture changes

### DIFF
--- a/city_furniture/admin/furniture_signpost.py
+++ b/city_furniture/admin/furniture_signpost.py
@@ -91,6 +91,8 @@ class AbstractFurnitureSignpostAdmin(
                 "additional_material_url",
                 "source_id",
                 "source_name",
+                "project_id",
+                "responsible_entity",
             )
         },
     )

--- a/city_furniture/models/common.py
+++ b/city_furniture/models/common.py
@@ -146,6 +146,9 @@ class CityFurnitureTarget(SourceControlModel):
         verbose_name = _("City Furniture Target")
         verbose_name_plural = _("City Furniture Targets")
 
+    def __str__(self):
+        return self.name_fi
+
 
 class ResponsibleEntity(models.Model):
     """
@@ -176,6 +179,17 @@ class ResponsibleEntity(models.Model):
         db_table = "responsible_entity"
         verbose_name = _("Responsible Entity")
         verbose_name_plural = _("Responsible Entities")
+
+    def get_full_path(self):
+        obj = self
+        path = obj.name
+        while obj.parent is not None:
+            obj = obj.parent
+            path = f"{obj.name} > {path}"
+        return path
+
+    def __str__(self):
+        return self.get_full_path()
 
 
 auditlog.register(CityFurnitureDeviceType)

--- a/city_furniture/resources/furniture_signpost.py
+++ b/city_furniture/resources/furniture_signpost.py
@@ -5,19 +5,13 @@ from import_export.widgets import ForeignKeyWidget
 from city_furniture.models import FurnitureSignpostPlan, FurnitureSignpostReal
 from city_furniture.models.common import CityFurnitureDeviceType, CityFurnitureTarget, ResponsibleEntity
 from city_furniture.resources.common import ResourceEnumIntegerField
-from traffic_control.enums import Condition, InstallationStatus, Lifecycle
+from traffic_control.enums import Condition, Lifecycle
 from traffic_control.models import MountType, Owner
 from users.utils import get_system_user
 
 
 class AbstractFurnitureSignpostResource(resources.ModelResource):
     lifecycle = ResourceEnumIntegerField(attribute="lifecycle", column_name="lifecycle", enum=Lifecycle)
-    condition = ResourceEnumIntegerField(attribute="condition", column_name="condition", enum=Condition)
-    installation_status = ResourceEnumIntegerField(
-        attribute="installation_status",
-        column_name="installation_status",
-        enum=InstallationStatus,
-    )
     owner = Field(
         attribute="owner",
         column_name="owner__name_fi",
@@ -56,12 +50,10 @@ class AbstractFurnitureSignpostResource(resources.ModelResource):
         )
         common_fields = (
             "id",
-            "source_name",
-            "source_id",
             "project_id",
             "owner__name_fi",
             "responsible_entity__name",
-            "location",  # TODO: Split into Lat and Long?
+            "location",
             "location_name",
             "location_additional_info",
             "direction",
@@ -69,7 +61,7 @@ class AbstractFurnitureSignpostResource(resources.ModelResource):
             "color__name",
             "height",
             "mount_type__code",
-            "parent",
+            "parent__id",
             "order",
             "pictogram",
             "value",
@@ -80,8 +72,8 @@ class AbstractFurnitureSignpostResource(resources.ModelResource):
             "text_content_fi",
             "text_content_sw",
             "text_content_en",
-            "validity_period_end",
             "validity_period_start",
+            "validity_period_end",
             "additional_material_url",
             "lifecycle",
         )
@@ -107,19 +99,20 @@ class FurnitureSignpostPlanResource(AbstractFurnitureSignpostResource):
         model = FurnitureSignpostPlan
 
         fields = AbstractFurnitureSignpostResource.Meta.common_fields + (
-            "mount_plan",
-            "plan",
+            "mount_plan__id",
+            "plan__plan_number",
         )
         export_order = fields
 
 
 class FurnitureSignpostRealResource(AbstractFurnitureSignpostResource):
+    condition = ResourceEnumIntegerField(attribute="condition", column_name="condition", enum=Condition)
+
     class Meta(AbstractFurnitureSignpostResource.Meta):
         model = FurnitureSignpostReal
 
         fields = AbstractFurnitureSignpostResource.Meta.common_fields + (
             "condition",
-            "installation_status",
             "installation_date",
             "furniture_signpost_plan__id",
             "mount_real__id",


### PR DESCRIPTION
- Make management command importer more sturdy
- Remove unused fields from FurnitureSignpost import/export resources
- Add `__str__` methods for `CityFurnitureTarget` and `ResponsibleEntity`
- Add missing fields to Furniture Signpost Admin forms