### PR TITLE
Fix deprecation warnings coming from Cityinfra code base

### DIFF
--- a/city-infrastructure-platform/urls.py
+++ b/city-infrastructure-platform/urls.py
@@ -1,8 +1,7 @@
 from django.conf import settings
-from django.conf.urls import url
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions, routers
@@ -144,9 +143,9 @@ urlpatterns = [
     path("v1/", include(furniture_signpost_operations_router.urls)),
     path("auth/", include("social_django.urls", namespace="social")),
     path("wfs/", CityInfrastructureWFSView.as_view(), name="wfs-city-infrastructure"),
-    url(r"^swagger(?P<format>\.json|\.yaml)$", schema_view.without_ui(cache_timeout=0), name="schema-json"),
-    url(r"^swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
-    url(r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    re_path(r"^swagger(?P<format>\.json|\.yaml)$", schema_view.without_ui(cache_timeout=0), name="schema-json"),
+    re_path(r"^swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
+    re_path(r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
     path("sentry-debug/", lambda a: 1 / 0),
 ]
 

--- a/map/models.py
+++ b/map/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Layer(models.Model):

--- a/map/views.py
+++ b/map/views.py
@@ -3,7 +3,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .models import Layer
 

--- a/traffic_control/models/affect_area.py
+++ b/traffic_control/models/affect_area.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.contrib.gis.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from traffic_control.mixins.models import SourceControlModel
 from traffic_control.models.common import Owner

--- a/traffic_control/tests/factories.py
+++ b/traffic_control/tests/factories.py
@@ -50,7 +50,7 @@ from traffic_control.tests.test_base_api_3d import test_point_3d
 
 def get_user(username=None, admin=False):
     if not username:
-        username = get_random_string()  # pragma: no cover
+        username = get_random_string(length=12)  # pragma: no cover
     return get_user_model().objects.get_or_create(
         username=username,
         password="x",

--- a/traffic_control/tests/models/test_mount.py
+++ b/traffic_control/tests/models/test_mount.py
@@ -51,5 +51,5 @@ class MountRealTestCase(TestCase):
         )
         self.assertQuerysetEqual(
             self.mount_real.ordered_traffic_signs,
-            [repr(traffic_sign_2), repr(traffic_sign_1), repr(traffic_sign_3)],
+            [traffic_sign_2, traffic_sign_1, traffic_sign_3],
         )

--- a/traffic_control/tests/models/test_traffic_control_device_type.py
+++ b/traffic_control/tests/models/test_traffic_control_device_type.py
@@ -43,7 +43,7 @@ def test__traffic_control_device_type__target_model__restricts_relations(allowed
     related_obj = factory()
 
     for choice in DeviceTypeTargetModel:
-        device_type = get_traffic_control_device_type(code=get_random_string(), target_model=choice)
+        device_type = get_traffic_control_device_type(code=get_random_string(length=12), target_model=choice)
 
         if choice == allowed_value:
             related_obj.device_type = device_type


### PR DESCRIPTION
We should update hel-users to fix warnings coming from there

```
.../site-packages/helusers/apps.py:8
  /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/helusers/apps.py:8: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    verbose_name = _("Helsinki Users")
...
```