### PR TITLE
Don't apply migrations in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN cd /map-view && \
 # ==============================
 FROM base AS production
 # ==============================
-ENV APPLY_MIGRATIONS=1
+ENV APPLY_MIGRATIONS=0
 ENV COLLECT_STATIC=1
 
 COPY . /city-infrastructure-platform

--- a/apply-migrations.sh
+++ b/apply-migrations.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+python ./manage.py migrate --noinput

--- a/check-migrations.sh
+++ b/check-migrations.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+python ./manage.py migrate --check

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,10 +2,19 @@
 
 set -e
 
-# Apply database migrations
+# Apply or validate database migrations
 if [[ "$APPLY_MIGRATIONS" = "1" ]]; then
     echo "Applying database migrations..."
-    python ./manage.py migrate --noinput
+    ./apply-migrations.sh
+else
+    echo "Checking that migrations are applied..."
+    error_code=0
+    ./check-migrations.sh || error_code=$?
+
+    if [ "$error_code" -ne 0 ]; then
+        echo "Migrations are not applied!"
+        exit $error_code
+    fi
 fi
 
 # Collect static files


### PR DESCRIPTION
Add `check-migrations.sh` and `apply-migrations.sh` scripts which hold
required commands. In OpenShift we will have `job`'s which run these
separately before starting API service pod(s). Pods only check that
migrations are applied before startup.