### PR TITLE
Hide user ids from object in anonymous requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 .grunt
 .hypothesis/
 .idea
+.vscode/
 .installed.cfg
 .ipynb_checkpoints
 .lock-wscript

--- a/city_furniture/serializers/furniture_signpost.py
+++ b/city_furniture/serializers/furniture_signpost.py
@@ -12,6 +12,7 @@ from city_furniture.models import (
 )
 from city_furniture.models.common import CityFurnitureDeviceType
 from traffic_control.models import OperationType
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class FurnitureSignpostPlanFileSerializer(serializers.ModelSerializer):
@@ -20,7 +21,11 @@ class FurnitureSignpostPlanFileSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class FurnitureSignpostPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class FurnitureSignpostPlanSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = FurnitureSignpostPlanFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=CityFurnitureDeviceType.objects.for_target_model(CityFurnitureDeviceTypeTargetModel.FURNITURE_SIGNPOST)
@@ -77,7 +82,11 @@ class FurnitureSignpostRealOperationSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class FurnitureSignpostRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class FurnitureSignpostRealSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = FurnitureSignpostRealFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=CityFurnitureDeviceType.objects.for_target_model(CityFurnitureDeviceTypeTargetModel.FURNITURE_SIGNPOST)

--- a/traffic_control/serializers/additional_sign.py
+++ b/traffic_control/serializers/additional_sign.py
@@ -12,6 +12,7 @@ from traffic_control.models import (
     TrafficControlDeviceType,
 )
 from traffic_control.models.additional_sign import AdditionalSignRealOperation
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class WritableNestedContentSerializerMixin:
@@ -99,7 +100,7 @@ class NestedAdditionalSignContentSerializerMixin:
         return value
 
 
-class AdditionalSignContentPlanSerializer(serializers.ModelSerializer):
+class AdditionalSignContentPlanSerializer(HideFromAnonUserSerializerMixin, serializers.ModelSerializer):
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.ADDITIONAL_SIGN)
     )
@@ -114,7 +115,9 @@ class AdditionalSignContentPlanSerializer(serializers.ModelSerializer):
 
 
 class NestedAdditionalSignContentPlanSerializer(
-    NestedAdditionalSignContentSerializerMixin, serializers.ModelSerializer
+    NestedAdditionalSignContentSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
 ):
     id = serializers.UUIDField(required=False)
     device_type = serializers.PrimaryKeyRelatedField(
@@ -130,6 +133,7 @@ class NestedAdditionalSignContentPlanSerializer(
 class AdditionalSignPlanSerializer(
     WritableNestedContentSerializerMixin,
     EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
     serializers.ModelSerializer,
 ):
     content = NestedAdditionalSignContentPlanSerializer(many=True, required=False)
@@ -150,7 +154,7 @@ class AdditionalSignPlanGeoJSONSerializer(AdditionalSignPlanSerializer):
     location = GeometryField(required=False)
 
 
-class AdditionalSignContentRealSerializer(serializers.ModelSerializer):
+class AdditionalSignContentRealSerializer(HideFromAnonUserSerializerMixin, serializers.ModelSerializer):
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.ADDITIONAL_SIGN)
     )
@@ -165,7 +169,9 @@ class AdditionalSignContentRealSerializer(serializers.ModelSerializer):
 
 
 class NestedAdditionalSignContentRealSerializer(
-    NestedAdditionalSignContentSerializerMixin, serializers.ModelSerializer
+    NestedAdditionalSignContentSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
 ):
     id = serializers.UUIDField(required=False)
     device_type = serializers.PrimaryKeyRelatedField(
@@ -205,6 +211,7 @@ class AdditionalSignRealOperationSerializer(serializers.ModelSerializer):
 class AdditionalSignRealSerializer(
     WritableNestedContentSerializerMixin,
     EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
     serializers.ModelSerializer,
 ):
     content = NestedAdditionalSignContentRealSerializer(many=True, required=False)

--- a/traffic_control/serializers/barrier.py
+++ b/traffic_control/serializers/barrier.py
@@ -12,6 +12,7 @@ from traffic_control.models import (
     TrafficControlDeviceType,
 )
 from traffic_control.models.barrier import BarrierRealOperation
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class BarrierPlanFileSerializer(serializers.ModelSerializer):
@@ -20,7 +21,11 @@ class BarrierPlanFileSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class BarrierPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class BarrierPlanSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = BarrierPlanFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.BARRIER)
@@ -71,7 +76,11 @@ class BarrierRealOperationSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class BarrierRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class BarrierRealSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = BarrierRealFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.BARRIER)

--- a/traffic_control/serializers/common.py
+++ b/traffic_control/serializers/common.py
@@ -11,6 +11,23 @@ from traffic_control.models import OperationalArea, Owner, TrafficControlDeviceT
 from traffic_control.schema import TrafficSignType
 
 
+class HideFromAnonUserSerializerMixin:
+    """
+    Don't include object's user information to unauthenticated requests
+    """
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        user = self.context["request"].user
+
+        if not user.is_authenticated:
+            representation.pop("created_by", None)
+            representation.pop("updated_by", None)
+            representation.pop("deleted_by", None)
+
+        return representation
+
+
 class TrafficControlDeviceTypeSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
     traffic_sign_type = serializers.SerializerMethodField(
         method_name="get_traffic_sign_type",

--- a/traffic_control/serializers/mount.py
+++ b/traffic_control/serializers/mount.py
@@ -12,6 +12,7 @@ from traffic_control.models import (
     PortalType,
 )
 from traffic_control.models.mount import MountRealOperation
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class PortalTypeSerializer(serializers.ModelSerializer):
@@ -32,7 +33,11 @@ class MountPlanFileSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class MountPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class MountPlanSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = MountPlanFileSerializer(many=True, read_only=True)
 
     class Meta:
@@ -80,7 +85,11 @@ class MountRealOperationSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class MountRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class MountRealSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     ordered_traffic_signs = serializers.PrimaryKeyRelatedField(read_only=True, many=True)
     files = MountRealFileSerializer(many=True, read_only=True)
     operations = MountRealOperationSerializer(many=True, required=False, read_only=True)

--- a/traffic_control/serializers/plan.py
+++ b/traffic_control/serializers/plan.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
 
 from traffic_control.models import Plan
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class PlanRelationSerializer(serializers.ModelSerializer):
@@ -61,7 +62,7 @@ class PlanRelationSerializer(serializers.ModelSerializer):
         )
 
 
-class PlanSerializer(serializers.ModelSerializer):
+class PlanSerializer(HideFromAnonUserSerializerMixin, serializers.ModelSerializer):
     linked_objects = PlanRelationSerializer(source="*", required=False, read_only=True)
 
     class Meta:

--- a/traffic_control/serializers/road_marking.py
+++ b/traffic_control/serializers/road_marking.py
@@ -12,6 +12,7 @@ from traffic_control.models import (
     TrafficControlDeviceType,
 )
 from traffic_control.models.road_marking import RoadMarkingRealOperation
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class RoadMarkingPlanFileSerializer(serializers.ModelSerializer):
@@ -20,7 +21,11 @@ class RoadMarkingPlanFileSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class RoadMarkingPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class RoadMarkingPlanSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = RoadMarkingPlanFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.ROAD_MARKING)
@@ -71,7 +76,11 @@ class RoadMarkingRealOperationSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class RoadMarkingRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class RoadMarkingRealSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = RoadMarkingRealFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.ROAD_MARKING)

--- a/traffic_control/serializers/signpost.py
+++ b/traffic_control/serializers/signpost.py
@@ -12,6 +12,7 @@ from traffic_control.models import (
     TrafficControlDeviceType,
 )
 from traffic_control.models.signpost import SignpostRealOperation
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class SignpostPlanFileSerializer(serializers.ModelSerializer):
@@ -20,7 +21,11 @@ class SignpostPlanFileSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class SignpostPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class SignpostPlanSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = SignpostPlanFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.SIGNPOST)
@@ -71,7 +76,11 @@ class SignpostRealOperationSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class SignpostRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class SignpostRealSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = SignpostRealFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.SIGNPOST)

--- a/traffic_control/serializers/traffic_light.py
+++ b/traffic_control/serializers/traffic_light.py
@@ -12,6 +12,7 @@ from traffic_control.models import (
     TrafficLightRealFile,
 )
 from traffic_control.models.traffic_light import TrafficLightRealOperation
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class TrafficLightPlanFileSerializer(serializers.ModelSerializer):
@@ -20,7 +21,11 @@ class TrafficLightPlanFileSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class TrafficLightPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class TrafficLightPlanSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = TrafficLightPlanFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.TRAFFIC_LIGHT)
@@ -71,7 +76,11 @@ class TrafficLightRealOperationSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class TrafficLightRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class TrafficLightRealSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = TrafficLightRealFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.TRAFFIC_LIGHT)

--- a/traffic_control/serializers/traffic_sign.py
+++ b/traffic_control/serializers/traffic_sign.py
@@ -12,6 +12,7 @@ from traffic_control.models import (
     TrafficSignRealFile,
 )
 from traffic_control.models.traffic_sign import TrafficSignRealOperation
+from traffic_control.serializers.common import HideFromAnonUserSerializerMixin
 
 
 class TrafficSignPlanFileSerializer(serializers.ModelSerializer):
@@ -20,7 +21,11 @@ class TrafficSignPlanFileSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class TrafficSignPlanSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class TrafficSignPlanSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = TrafficSignPlanFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.TRAFFIC_SIGN)
@@ -71,7 +76,11 @@ class TrafficSignRealOperationSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class TrafficSignRealSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+class TrafficSignRealSerializer(
+    EnumSupportSerializerMixin,
+    HideFromAnonUserSerializerMixin,
+    serializers.ModelSerializer,
+):
     files = TrafficSignRealFileSerializer(many=True, read_only=True)
     device_type = serializers.PrimaryKeyRelatedField(
         queryset=TrafficControlDeviceType.objects.for_target_model(DeviceTypeTargetModel.TRAFFIC_SIGN)

--- a/traffic_control/tests/test_additional_sign_plan_api.py
+++ b/traffic_control/tests/test_additional_sign_plan_api.py
@@ -625,7 +625,8 @@ def test__additional_sign_content_plan__list():
 
 @pytest.mark.django_db
 def test__additional_sign_content_plan__detail():
-    client = get_api_client()
+    user = get_user()
+    client = get_api_client(user=user)
     dt = get_traffic_control_device_type(code="H17.1")
     ascp = get_additional_sign_content_plan(device_type=dt)
 

--- a/traffic_control/tests/test_additional_sign_real_api.py
+++ b/traffic_control/tests/test_additional_sign_real_api.py
@@ -634,7 +634,8 @@ def test__additional_sign_content_real__list():
 
 @pytest.mark.django_db
 def test__additional_sign_content_real__detail():
-    client = get_api_client()
+    user = get_user()
+    client = get_api_client(user)
     dt = get_traffic_control_device_type(code="H17.1")
     ascr = get_additional_sign_content_real(device_type=dt)
 

--- a/traffic_control/tests/test_anonymous_requests.py
+++ b/traffic_control/tests/test_anonymous_requests.py
@@ -1,0 +1,132 @@
+from typing import Callable
+
+import pytest
+from django.urls import reverse
+
+from city_furniture.tests.factories import get_furniture_signpost_plan, get_furniture_signpost_real
+from traffic_control.tests.factories import (
+    get_additional_sign_content_plan,
+    get_additional_sign_content_real,
+    get_additional_sign_plan,
+    get_additional_sign_real,
+    get_api_client,
+    get_barrier_plan,
+    get_barrier_real,
+    get_mount_plan,
+    get_mount_real,
+    get_plan,
+    get_road_marking_plan,
+    get_road_marking_real,
+    get_signpost_plan,
+    get_signpost_real,
+    get_traffic_light_plan,
+    get_traffic_light_real,
+    get_traffic_sign_plan,
+    get_traffic_sign_real,
+)
+
+
+def validate_dict(object: dict, validate_keys: Callable[[dict], None]):
+    """
+    Recursively validate nested dicts and lists of dicts with function `validate_keys`
+    """
+    validate_keys(object)
+
+    for _, value in object.items():
+
+        if isinstance(value, dict):
+            validate_dict(value, validate_keys)
+
+        elif isinstance(value, list):
+            for list_item in value:
+                if isinstance(list_item, dict):
+                    validate_dict(list_item, validate_keys)
+
+
+def assert_no_user_ids(object: dict):
+    assert object.get("created_by") is None
+    assert object.get("updated_by") is None
+    assert object.get("deleted_by") is None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "endpoint_name,device_factory",
+    (
+        ("v1:additionalsigncontentplan", get_additional_sign_content_plan),
+        ("v1:additionalsigncontentreal", get_additional_sign_content_real),
+        ("v1:additionalsignplan", get_additional_sign_plan),
+        ("v1:additionalsignreal", get_additional_sign_real),
+        ("v1:barrierplan", get_barrier_plan),
+        ("v1:barrierreal", get_barrier_real),
+        ("v1:mountplan", get_mount_plan),
+        ("v1:mountreal", get_mount_real),
+        ("v1:plan", get_plan),
+        ("v1:roadmarkingplan", get_road_marking_plan),
+        ("v1:roadmarkingreal", get_road_marking_real),
+        ("v1:signpostplan", get_signpost_plan),
+        ("v1:signpostreal", get_signpost_real),
+        ("v1:trafficlightplan", get_traffic_light_plan),
+        ("v1:trafficlightreal", get_traffic_light_real),
+        ("v1:trafficsignplan", get_traffic_sign_plan),
+        ("v1:trafficsignreal", get_traffic_sign_real),
+        ("v1:furnituresignpostplan", get_furniture_signpost_plan),
+        ("v1:furnituresignpostreal", get_furniture_signpost_real),
+    ),
+)
+def test__hide_user_info_from_anonymous_request_single(
+    endpoint_name: str,
+    device_factory: Callable,
+):
+    client = get_api_client()
+    device_object = device_factory()
+
+    endpoint = f"{endpoint_name}-detail"
+
+    response = client.get(reverse(endpoint, kwargs={"pk": device_object.id}))
+    response_data = response.json()
+
+    validate_dict(response_data, assert_no_user_ids)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "endpoint_name,device_factory",
+    (
+        ("v1:additionalsigncontentplan", get_additional_sign_content_plan),
+        ("v1:additionalsigncontentreal", get_additional_sign_content_real),
+        ("v1:additionalsignplan", get_additional_sign_plan),
+        ("v1:additionalsignreal", get_additional_sign_real),
+        ("v1:barrierplan", get_barrier_plan),
+        ("v1:barrierreal", get_barrier_real),
+        ("v1:mountplan", get_mount_plan),
+        ("v1:mountreal", get_mount_real),
+        ("v1:plan", get_plan),
+        ("v1:roadmarkingplan", get_road_marking_plan),
+        ("v1:roadmarkingreal", get_road_marking_real),
+        ("v1:signpostplan", get_signpost_plan),
+        ("v1:signpostreal", get_signpost_real),
+        ("v1:trafficlightplan", get_traffic_light_plan),
+        ("v1:trafficlightreal", get_traffic_light_real),
+        ("v1:trafficsignplan", get_traffic_sign_plan),
+        ("v1:trafficsignreal", get_traffic_sign_real),
+        ("v1:furnituresignpostplan", get_furniture_signpost_plan),
+        ("v1:furnituresignpostreal", get_furniture_signpost_real),
+    ),
+)
+def test__hide_user_info_from_anonymous_request_list(
+    endpoint_name: str,
+    device_factory: Callable,
+):
+    client = get_api_client()
+    device_factory()
+
+    endpoint = f"{endpoint_name}-list"
+
+    response = client.get(reverse(endpoint))
+    response_data = response.json()
+    devices = response_data["results"]
+
+    assert len(devices) == 1
+    for device in devices:
+        validate_dict(device, assert_no_user_ids)


### PR DESCRIPTION
Hide created_by, updated_by and deleted_by from non-logged in users for data privacy, even when user ids are just UUID values.

Refs LIIK-367