### PR TITLE
Fix backend error if traffic sign icon name has no dots

### DIFF
--- a/traffic_control/forms.py
+++ b/traffic_control/forms.py
@@ -54,7 +54,7 @@ class AdminTrafficSignIconSelectWidget(Select):
             id_icon_values = TrafficControlDeviceType.objects.values_list("id", "icon")
             for uuid, icon in id_icon_values:
                 if icon:
-                    icon_name, ext = icon.rsplit(".", maxsplit=1)
+                    icon_name = icon.rsplit(".", maxsplit=1)[0]
                     icon_path = f"{settings.STATIC_URL}traffic_control/svg/traffic_sign_icons/{icon_name.upper()}.svg"
                     self.icon_url_mapping[uuid] = icon_path
         return self.icon_url_mapping.get(value, "")

--- a/traffic_control/static/traffic_control/js/traffic_sign_icon_select.js
+++ b/traffic_control/static/traffic_control/js/traffic_sign_icon_select.js
@@ -6,5 +6,6 @@
  */
 function updateTrafficSignIcon(icon, iconUrl) {
   icon.src = iconUrl;
+  icon.alt = iconUrl.split("/").pop();
   icon.style.display = iconUrl ? "block" : "none";
 }

--- a/traffic_control/templates/admin/traffic_control/widgets/traffic_sign_icon_select.html
+++ b/traffic_control/templates/admin/traffic_control/widgets/traffic_sign_icon_select.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<img class="traffic-sign-icon" src="{{ icon_path }}" alt="Traffic sign icon" {% if not icon_path %}style="display: none;"{% endif %}>
+<img class="traffic-sign-icon" src="{{ icon_path }}" alt="{{ icon_path }}" {% if not icon_path %}style="display: none;"{% endif %}>
 
 {# Default select widget template with added onchange attribute #}
 <select name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}


### PR DESCRIPTION
It expected icon name being like "name.svg" or "some.name.svg"

Refs LIIK-385