### PR TITLE
Don't log readiness and health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY poetry.lock pyproject.toml /city-infrastructure-platform/
 RUN apt-get update && \
     mkdir -p /usr/share/man/man1/ /usr/share/man/man3/ /usr/share/man/man7/ && \
     apt-get install -y --no-install-recommends \
+        libpcre3-dev \
         libpq-dev \
         build-essential \
         gdal-bin \

--- a/uwsgi_docker.ini
+++ b/uwsgi_docker.ini
@@ -13,3 +13,7 @@ threads = 2
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true
+
+; Don't log readiness and health check routes to reduce noise
+route = ^/healthz$ donotlog:
+route = ^/readiness$ donotlog:


### PR DESCRIPTION
To reduce noise in logs, we suppress /healthz and /readiness requests.

Install pcre library to support uWSGI internal routing, which is required by route rules to ignore specific logging.