### PR TITLE
Use bounding box coordinate swapping functionality

### DIFF
--- a/traffic_control/tests/wfs/test_common_wfs.py
+++ b/traffic_control/tests/wfs/test_common_wfs.py
@@ -1,0 +1,68 @@
+import pytest
+from django.contrib.gis.geos import Point
+
+from city_furniture.models import FurnitureSignpostPlan, FurnitureSignpostReal
+from city_furniture.tests.factories import get_furniture_signpost_plan, get_furniture_signpost_real
+from traffic_control.models import AdditionalSignPlan, AdditionalSignReal, TrafficSignPlan, TrafficSignReal
+from traffic_control.tests.factories import (
+    get_additional_sign_plan,
+    get_additional_sign_real,
+    get_traffic_sign_plan,
+    get_traffic_sign_real,
+)
+from traffic_control.tests.wfs.wfs_utils import (
+    EPSG_3879_URN,
+    geojson_feature_id,
+    geojson_get_features,
+    gml_feature_id,
+    gml_get_features,
+    wfs_get_features_geojson,
+    wfs_get_features_gml,
+)
+
+
+@pytest.mark.parametrize(
+    "model, model_name, factory",
+    (
+        (TrafficSignPlan, "trafficsignplan", get_traffic_sign_plan),
+        (TrafficSignReal, "trafficsignreal", get_traffic_sign_real),
+        (AdditionalSignPlan, "additionalsignplan", get_additional_sign_plan),
+        (AdditionalSignReal, "additionalsignreal", get_additional_sign_real),
+        (FurnitureSignpostPlan, "furnituresignpostplan", get_furniture_signpost_plan),
+        (FurnitureSignpostReal, "furnituresignpostreal", get_furniture_signpost_real),
+    ),
+)
+@pytest.mark.parametrize("bbox_has_crs", (True, False))
+@pytest.mark.parametrize("output_format", ("gml", "geojson"))
+@pytest.mark.django_db
+def test__wfs__get_feature_bounding_box(model, model_name: str, factory, bbox_has_crs, output_format):
+    """
+    Ensure getting correct set of devices using bounding box filtering
+    """
+
+    # BBOX parameter order is (south, west, north, east) in EPSG:3879
+    bbox = "10.0,0.0,20.0,10.0"
+    if bbox_has_crs:
+        bbox += f",{EPSG_3879_URN}"
+
+    # Create two devices, one outside and one inside the bounding box
+    factory(location=Point(25, 15, 0, srid=3879))
+    device_in = factory(location=Point(5, 15, 0, srid=3879))
+
+    if output_format == "gml":
+        response = wfs_get_features_gml(model_name, bbox=bbox)
+        features = gml_get_features(response, model_name)
+    elif output_format == "geojson":
+        response = wfs_get_features_geojson(model_name, bbox=bbox)
+        features = geojson_get_features(response)
+
+    assert model.objects.count() == 2
+    assert len(features) == 1
+    feature = features[0]
+
+    if output_format == "gml":
+        feature_id = gml_feature_id(feature)
+    elif output_format == "geojson":
+        feature_id = geojson_feature_id(feature)
+
+    assert feature_id == f"{model_name}.{device_in.id}"

--- a/traffic_control/tests/wfs/wfs_utils.py
+++ b/traffic_control/tests/wfs/wfs_utils.py
@@ -26,6 +26,7 @@ def wfs_url_get_features(
     type_names: Union[str, List[str]],
     srs_name: Optional[str] = None,
     output_format: Optional[str] = None,
+    bbox: Optional[str] = None,
 ) -> str:
     base_url = f"{reverse('wfs-city-infrastructure')}?"
 
@@ -39,6 +40,7 @@ def wfs_url_get_features(
         "typeNames": type_names,
         "outputFormat": output_format,
         "srsName": srs_name,
+        "bbox": bbox,
     }
 
     non_none_params = {k: v for k, v in params.items() if v is not None}
@@ -46,20 +48,26 @@ def wfs_url_get_features(
     return base_url + urlencode(non_none_params)
 
 
-def wfs_get_features_gml(model_name) -> ElementTree.Element:
+def wfs_get_features_gml(
+    model_name,
+    bbox: Optional[str] = None,
+) -> ElementTree.Element:
     client = get_api_client()
 
-    response = client.get(wfs_url_get_features(model_name))
+    response = client.get(wfs_url_get_features(model_name, bbox=bbox))
     assert response.status_code == status.HTTP_200_OK
 
     xml = get_response_content(response)
     return ElementTree.fromstring(xml)
 
 
-def wfs_get_features_geojson(model_name) -> dict:
+def wfs_get_features_geojson(
+    model_name,
+    bbox: Optional[str] = None,
+) -> dict:
     client = get_api_client()
 
-    response = client.get(wfs_url_get_features(model_name, output_format="geojson"))
+    response = client.get(wfs_url_get_features(model_name, output_format="geojson", bbox=bbox))
     assert response.status_code == status.HTTP_200_OK
 
     geojson = get_response_content(response)

--- a/traffic_control/views/wfs/common.py
+++ b/traffic_control/views/wfs/common.py
@@ -9,7 +9,7 @@ from gisserver.operations.wfs20 import GetFeature
 from gisserver.output import GeoJsonRenderer
 from gisserver.types import XsdElement
 
-from .utils import YXGML32Renderer
+from traffic_control.views.wfs.utils import SwapBoundingBoxMixin, YXGML32Renderer
 
 DEFAULT_CRS = CRS.from_srid(settings.SRID)
 
@@ -28,7 +28,7 @@ class CustomGeoJsonRenderer(GeoJsonRenderer):
         return super()._format_geojson_value(value)
 
 
-class CustomGetFeature(GetFeature):
+class CustomGetFeature(SwapBoundingBoxMixin, GetFeature):
     # Use CustomGeoJsonRenderer
     output_formats = [
         OutputFormat("application/gml+xml", version="3.2", renderer_class=YXGML32Renderer, title="GML"),


### PR DESCRIPTION
Fix missing use of `SwapBoundingBoxMixin` hack. Also fix it's `get_query` method's logics how it uses CRS in query parameters.

Add test cases to ensure WFS working with bounding box filtering.

Refs LIIK-472