### PR TITLE
Trigger SonarCloud scan from GitHub Actions pipeline

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Run pytest code functionality tests
       run: |
-        pytest -ra -vvv --cov=.
+        pytest -ra -vvv --cov=. --cov-report=xml --junitxml=test-results.xml
 
     - name: Install NodeJS dependencies
       run: |
@@ -74,7 +74,18 @@ jobs:
 
     - name: Run NodeJS code functionality tests
       run: |
-        yarn --cwd map-view test
+        yarn --cwd map-view test --ci --coverage --watchAll=false
+
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      with:
+        args: >
+          -Dsonar.projectKey=City-of-Helsinki_city-infrastructure-platform
+          -Dsonar.organization=city-of-helsinki
+          -Dsonar.python.version=3.8
 
     # Majority of the tests require database
     services:


### PR DESCRIPTION
Coverage analysis requires coverage files to be generated in pipeline.

Most Sonar configuration is defined in SonarCloud.

Refs LIIK-499