### PR TITLE
Bump `django-import-export` to 3.2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -770,20 +770,20 @@ requests = "*"
 
 [[package]]
 name = "django-import-export"
-version = "2.9.0"
+version = "3.2.0"
 description = "Django application and library for importing and exporting data with included admin integration."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "django-import-export-2.9.0.tar.gz", hash = "sha256:02ce3a8e191992fa7aa1d660877ac6764fa9e32a5ba6394293f2fc761a5bdd19"},
-    {file = "django_import_export-2.9.0-py3-none-any.whl", hash = "sha256:126d32a4410c42b6e1bf060355bf45968f6fe427c3b7ed04c96873bd45d7549a"},
+    {file = "django-import-export-3.2.0.tar.gz", hash = "sha256:38fd7b9439b9e3aa1a4747421c1087a5bc194e915a28d795fb8429a5f8028f2d"},
+    {file = "django_import_export-3.2.0-py3-none-any.whl", hash = "sha256:1d3f2cb2ee3cca0386ed60651fa1623be989f130d9fbdf98a67f7dc3a94b8a37"},
 ]
 
 [package.dependencies]
 diff-match-patch = "*"
 Django = ">=3.2"
-tablib = {version = ">=3.0.0", extras = ["html", "ods", "xls", "xlsx", "yaml"]}
+tablib = {version = ">=3.4.0", extras = ["html", "ods", "xls", "xlsx", "yaml"]}
 
 [[package]]
 name = "django-js-asset"
@@ -2377,14 +2377,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "tablib"
-version = "3.3.0"
-description = "Format agnostic tabular data library (XLS, JSON, YAML, CSV)"
+version = "3.4.0"
+description = "Format agnostic tabular data library (XLS, JSON, YAML, CSV, etc.)"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tablib-3.3.0-py3-none-any.whl", hash = "sha256:f7f2e214a1a68577f2599927a8870495adac0f7f2673b1819130f2060e1914ab"},
-    {file = "tablib-3.3.0.tar.gz", hash = "sha256:11e02a6f81d256e0666877d8397972d10302307a54c04fd7157e92faf740cb10"},
+    {file = "tablib-3.4.0-py3-none-any.whl", hash = "sha256:0f9c45141195c472202f30d82c0c035bf7e0dd7e4da2257815e506acff4ab364"},
+    {file = "tablib-3.4.0.tar.gz", hash = "sha256:77ea97faf6f92a7e198c05bd0c690f3cba57b83ea45a636b72f967cb6fe6f160"},
 ]
 
 [package.dependencies]
@@ -2586,4 +2586,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "3984ab96e01c3b70666d1ca7d6d9e572896cf804f9fdad24deb85c0caa40df99"
+content-hash = "a93dd3f9c0634909ce93de444cc9eb42b1821aaf3f36b949205e356050dea19d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -696,14 +696,14 @@ Django = ">=3.2"
 
 [[package]]
 name = "django-filter"
-version = "23.1"
+version = "23.2"
 description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "django-filter-23.1.tar.gz", hash = "sha256:dee5dcf2cea4d7f767e271b6d01f767fce7500676d5e5dc58dac8154000b87df"},
-    {file = "django_filter-23.1-py3-none-any.whl", hash = "sha256:e3c52ad83c32fb5882125105efb5fea2a1d6a85e7dc64b04ef52edbf14451b6c"},
+    {file = "django-filter-23.2.tar.gz", hash = "sha256:2fe15f78108475eda525692813205fa6f9e8c1caf1ae65daa5862d403c6dbf00"},
+    {file = "django_filter-23.2-py3-none-any.whl", hash = "sha256:d12d8e0fc6d3eb26641e553e5d53b191eb8cec611427d4bdce0becb1f7c172b5"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ django-filter = "^23.1"
 django-gisserver = "1.2.5"
 django-health-check = "^3.17.0"
 django-helusers = "^0.7.1"
-django-import-export = "^2.7.1"
+django-import-export = "^3.2.0"
 django-mptt = "^0.14.0"
 django-storages = { extras = ["azure"], version = "^1.13.2" }
 djangorestframework = "^3.14.0"

--- a/traffic_control/admin/utils.py
+++ b/traffic_control/admin/utils.py
@@ -180,20 +180,20 @@ class MultiResourceExportActionAdminMixin:
                 export_resource_choices=export_resource_choices,
             )
 
-    def get_export_resource_class(self, **kwargs) -> Type[ModelResource]:
+    def pick_export_resource_class(self, **kwargs) -> Type[ModelResource]:
         """Return export resource class to be used for exporting"""
         request = kwargs.pop("request", None)
         export_resource = request.POST.get("export_resource_class", None)
 
         # Use default export_resource if nothing is specified
         if export_resource is None or export_resource == "":
-            return super().get_export_resource_class()
+            return super().get_export_resource_classes()[0]
 
         return self.extra_export_resource_classes[int(export_resource)]
 
     def get_data_for_export(self, request, queryset, *args, **kwargs) -> tablib.Dataset:
-        """Override super's method to pass `request` to `self.get_export_resource_class` as a kwarg"""
-        resource_class: ModelResource = self.get_export_resource_class(request=request)()
+        """Override super's method to pass `request` to `self.pick_export_resource_class` as a kwarg"""
+        resource_class: ModelResource = self.pick_export_resource_class(request=request)()
         return resource_class.export(queryset, *args, **kwargs)
 
     @property


### PR DESCRIPTION
Version 3 adds support for multiple resource classes, which is what Cityinfra supports, but little differently. Instead of refactoring import/export functionality, here we just modify export so that things work as it worked before library update.