### PR TITLE
Support importing parent and child devices in same Excel/CSV file

### DIFF
--- a/city_furniture/tests/factories.py
+++ b/city_furniture/tests/factories.py
@@ -58,7 +58,14 @@ def get_city_furniture_device_type(
     )[0]
 
 
-def get_furniture_signpost_plan(location=None, owner=None, device_type=None, mount_plan=None):
+def get_furniture_signpost_plan(
+    location=None,
+    owner=None,
+    device_type=None,
+    parent=None,
+    mount_plan=None,
+    location_name_en=None,
+):
     user = get_user("test_user")
     location = location or test_point_3d
     owner = owner or get_owner()
@@ -66,6 +73,7 @@ def get_furniture_signpost_plan(location=None, owner=None, device_type=None, mou
 
     return FurnitureSignpostPlan.objects.get_or_create(
         location=location,
+        location_name_en=location_name_en,
         owner=owner,
         device_type=device_type,
         direction=90,
@@ -74,13 +82,20 @@ def get_furniture_signpost_plan(location=None, owner=None, device_type=None, mou
         source_name="Some_source",
         source_id=uuid.uuid4(),
         responsible_entity=get_responsible_entity(),
+        parent=parent,
         created_by=user,
         updated_by=user,
     )[0]
 
 
 def get_furniture_signpost_real(
-    location=None, owner=None, device_type=None, furniture_signpost_plan=None, mount_real=None
+    location=None,
+    owner=None,
+    device_type=None,
+    furniture_signpost_plan=None,
+    parent=None,
+    mount_real=None,
+    location_name_en=None,
 ):
     user = get_user("test_user")
     location = location or test_point_3d
@@ -93,6 +108,7 @@ def get_furniture_signpost_real(
             or get_furniture_signpost_plan(location=location, owner=owner, device_type=device_type)
         ),
         location=location,
+        location_name_en=location_name_en,
         owner=owner,
         device_type=device_type,
         direction=90,
@@ -102,6 +118,7 @@ def get_furniture_signpost_real(
         source_name="Some_source",
         source_id=uuid.uuid4(),
         responsible_entity=get_responsible_entity(),
+        parent=parent,
         created_by=user,
         updated_by=user,
     )[0]

--- a/city_furniture/tests/test_furniture_signpost_import_export.py
+++ b/city_furniture/tests/test_furniture_signpost_import_export.py
@@ -1,9 +1,12 @@
+from uuid import UUID
+
 import pytest
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 
-from city_furniture.models import FurnitureSignpostReal
+from city_furniture.models import FurnitureSignpostPlan, FurnitureSignpostReal
 from city_furniture.resources.furniture_signpost import (
+    FurnitureSignpostPlanResource,
     FurnitureSignpostPlanTemplateResource,
     FurnitureSignpostRealResource,
 )
@@ -11,6 +14,8 @@ from city_furniture.tests.factories import get_furniture_signpost_plan, get_furn
 from traffic_control.enums import OrganizationLevel
 from traffic_control.models import GroupResponsibleEntity, ResponsibleEntity
 from traffic_control.tests.factories import get_mount_plan, get_mount_real, get_user
+from traffic_control.tests.import_export.utils import file_formats, get_import_dataset
+from traffic_control.tests.test_base_api import test_point_2
 
 
 @pytest.mark.django_db
@@ -43,18 +48,43 @@ def test__furniture_signpost_real__import():
 
 @pytest.mark.parametrize("has_mount_plan", (True, False), ids=lambda x: "mount_plan" if x else "no_mount_plan")
 @pytest.mark.parametrize("has_mount_real", (True, False), ids=lambda x: "mount_real" if x else "no_mount_real")
+@pytest.mark.parametrize("has_parent_plan", (True, False), ids=lambda x: "parent_plan" if x else "no_parent_plan")
+@pytest.mark.parametrize("has_parent_real", (True, False), ids=lambda x: "parent_real" if x else "no_parent_real")
 @pytest.mark.parametrize("real_preexists", (True, False), ids=lambda x: "real_preexists" if x else "real_nonexists")
 @pytest.mark.django_db
-def test__furniture_signpost_plan_export_real_import(has_mount_plan, has_mount_real, real_preexists):
-    """Test that a plan object can be exported using a special resource and then be imported as real"""
+def test__furniture_signpost_plan_export_real(
+    has_mount_plan,
+    has_mount_real,
+    has_parent_plan,
+    has_parent_real,
+    real_preexists,
+):
+    """Test that a plan object can be exported as its real object (referencing to the plan)"""
 
     mount_plan = get_mount_plan() if has_mount_plan else None
     mount_real = get_mount_real() if has_mount_real else None
+    parent_plan = get_furniture_signpost_plan() if has_parent_plan else None
+    parent_real = get_furniture_signpost_real(furniture_signpost_plan=parent_plan) if has_parent_real else None
 
-    plan_obj = get_furniture_signpost_plan(mount_plan=mount_plan)
-    real_obj = get_furniture_signpost_real(furniture_signpost_plan=plan_obj) if real_preexists else None
+    plan_obj = get_furniture_signpost_plan(
+        location=test_point_2,
+        mount_plan=mount_plan,
+        parent=parent_plan,
+    )
+    real_obj = (
+        get_furniture_signpost_real(
+            location=test_point_2,
+            furniture_signpost_plan=plan_obj,
+            parent=parent_real,
+        )
+        if real_preexists
+        else None
+    )
 
-    exported_dataset = FurnitureSignpostPlanTemplateResource().export()
+    exported_dataset = FurnitureSignpostPlanTemplateResource().export(
+        queryset=FurnitureSignpostPlan.objects.filter(id=plan_obj.id)
+    )
+    assert len(exported_dataset) == 1
 
     real = exported_dataset.dict[0]
     assert real["furniture_signpost_plan__id"] == plan_obj.id
@@ -64,10 +94,126 @@ def test__furniture_signpost_plan_export_real_import(has_mount_plan, has_mount_r
     else:
         assert real["mount_real__id"] is None
 
+    if has_parent_plan:
+        if has_parent_real:
+            assert real["parent__id"] == parent_real.id
+        else:
+            if real_preexists:
+                assert real["parent__id"] == 1
+            else:
+                assert real["parent__id"] == 1
+    else:
+        assert real["parent__id"] is None
+
     if real_preexists:
         assert real["id"] == real_obj.id
     else:
         assert real["id"] is None
+
+
+@pytest.mark.django_db
+def test__furniture_signpost_plan_export_real_replacement_importable():
+    """
+    Test that a plan objects can be exported to real objects with parent-child id replacements
+    and the result is importable.
+    """
+
+    get_furniture_signpost_plan(location_name_en="A")
+    plan_b = get_furniture_signpost_plan(location_name_en="B")
+    get_furniture_signpost_plan(location_name_en="C", parent=plan_b)
+    plan_d = get_furniture_signpost_plan(location_name_en="D", parent=plan_b)
+    get_furniture_signpost_plan(location_name_en="E", parent=plan_d)
+
+    exported_dataset = FurnitureSignpostPlanTemplateResource().export()
+    assert len(exported_dataset) == 5
+
+    import_result = FurnitureSignpostRealResource().import_data(exported_dataset, raise_errors=False)
+    assert not import_result.has_errors()
+    assert FurnitureSignpostReal.objects.all().count() == 5
+
+
+@pytest.mark.parametrize(
+    "parent_real_preexists",
+    (True, False),
+    ids=lambda x: "parent_real_preexists" if x else "parent_real_nonexists",
+)
+@pytest.mark.parametrize(
+    "child_real_preexists",
+    (True, False),
+    ids=lambda x: "child_real_preexists" if x else "child_real_nonexists",
+)
+@pytest.mark.django_db
+def test__furniture_signpost_plan_export_real_parent_and_child(parent_real_preexists, child_real_preexists):
+    plan_parent = get_furniture_signpost_plan()
+    plan_child = get_furniture_signpost_plan(parent=plan_parent)
+
+    if parent_real_preexists:
+        real_parent = get_furniture_signpost_real(furniture_signpost_plan=plan_parent)
+    else:
+        real_parent = None
+
+    if child_real_preexists:
+        real_child = get_furniture_signpost_real(furniture_signpost_plan=plan_child)
+    else:
+        real_child = None
+
+    exported_dataset = FurnitureSignpostPlanTemplateResource().export()
+    assert len(exported_dataset) == 2
+
+    assert exported_dataset["furniture_signpost_plan__id"] == [
+        plan_parent.id,
+        plan_child.id,
+    ]
+
+    if parent_real_preexists:
+        if child_real_preexists:
+            expected_ids = [
+                real_parent.id,
+                real_child.id,
+            ]
+            expected_parent_ids = [
+                None,
+                real_parent.id,
+            ]
+        else:
+            expected_ids = [
+                real_parent.id,
+                None,
+            ]
+            expected_parent_ids = [
+                None,
+                real_parent.id,
+            ]
+    else:
+        if child_real_preexists:
+            expected_ids = [
+                1,
+                real_child.id,
+            ]
+            expected_parent_ids = [
+                None,
+                1,
+            ]
+        else:
+            expected_ids = [
+                1,
+                None,
+            ]
+            expected_parent_ids = [None, 1]
+
+    assert exported_dataset["id"] == expected_ids
+    assert exported_dataset["parent__id"] == expected_parent_ids
+
+    # Import
+    import_result = FurnitureSignpostRealResource().import_data(exported_dataset, raise_errors=False)
+    assert not import_result.has_errors()
+    assert FurnitureSignpostReal.objects.all().count() == 2
+
+    imported_parent_real = FurnitureSignpostReal.objects.get(furniture_signpost_plan=plan_parent)
+    imported_child_real = FurnitureSignpostReal.objects.get(furniture_signpost_plan=plan_child)
+    assert imported_parent_real.parent_id is None
+    assert imported_child_real.parent_id == imported_parent_real.id
+    assert imported_parent_real.id != UUID(int=1)
 
 
 @pytest.mark.django_db
@@ -122,3 +268,33 @@ def test__furniture_signpost_real__import__responsible_entity_permission_bypass(
 
     result = FurnitureSignpostRealResource().import_data(dataset, raise_errors=True, user=user)
     assert not result.has_errors()
+
+
+@pytest.mark.parametrize(
+    ("model", "resource", "factory"),
+    (
+        (FurnitureSignpostReal, FurnitureSignpostRealResource, get_furniture_signpost_real),
+        (FurnitureSignpostPlan, FurnitureSignpostPlanResource, get_furniture_signpost_plan),
+    ),
+)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db()
+def test__furniture_signpost__import__replace_parent_child_ids(model, resource, factory, format):
+    """Test that parent and child ids are replaced with the actual objects"""
+    parent = factory(location_name_en="A")
+    child = factory(location_name_en="B")
+
+    dataset = get_import_dataset(resource, format, delete_columns=["id", "parent__id"])
+    dataset = dataset.sort("location_name_en")
+    dataset.append_col(["1", None], header="id")
+    dataset.append_col([None, "1"], header="parent__id")
+
+    model.objects.all().delete()
+    assert model.objects.count() == 0
+
+    result = resource().import_data(dataset, raise_errors=False, collect_failed_rows=True)
+    assert not result.has_errors()
+
+    imported_parent = model.objects.get(location_name_en=parent.location_name_en)
+    imported_child = model.objects.get(location_name_en=child.location_name_en)
+    assert imported_child.parent_id == imported_parent.id

--- a/traffic_control/resources/additional_sign.py
+++ b/traffic_control/resources/additional_sign.py
@@ -87,6 +87,7 @@ class AbstractAdditionalSignResource(ResponsibleEntityPermissionImportMixin, Gen
         )
 
     def before_import(self, dataset, using_transactions, dry_run, **kwargs):
+        super().before_import(dataset, using_transactions, dry_run, **kwargs)
         self._content_s_from_columns(dataset)
 
     def after_export(self, queryset, data, *args, **kwargs):

--- a/traffic_control/resources/common.py
+++ b/traffic_control/resources/common.py
@@ -37,6 +37,18 @@ class EnumWidget(widgets.Widget):
         return force_str(value.name)
 
 
+class UUIDWidget(widgets.Widget):
+    def clean(self, value, row=None, *args, **kwargs):
+        if value in [None, ""]:
+            return None
+        if isinstance(value, UUID):
+            return value
+        try:
+            return UUID(str(value))
+        except ValueError:
+            raise ValueError("Value '%s' is not a valid UUID." % value)
+
+
 class ResourceUUIDField(fields.Field):
     def get_value(self, obj):
         """Convert UUID to string to prevent the importer from thinking the value is changed, when it's not"""
@@ -48,7 +60,7 @@ class ResourceUUIDField(fields.Field):
 
 
 class GenericDeviceBaseResource(ModelResource):
-    id = ResourceUUIDField(attribute="id", column_name="id", default=None)
+    id = ResourceUUIDField(attribute="id", column_name="id", default=None, widget=UUIDWidget())
 
     @classmethod
     def field_from_django_field(cls, field_name, django_field, readonly):

--- a/traffic_control/tests/factories.py
+++ b/traffic_control/tests/factories.py
@@ -212,7 +212,14 @@ def get_road_marking_real(location="", device_type=None, road_marking_plan=None,
     )[0]
 
 
-def get_signpost_plan(location="", plan=None, device_type=None, parent=None, mount_plan=None):
+def get_signpost_plan(
+    location="",
+    plan=None,
+    device_type=None,
+    parent=None,
+    mount_plan=None,
+    txt=None,
+):
     user = get_user("test_user")
 
     return SignpostPlan.objects.get_or_create(
@@ -223,12 +230,20 @@ def get_signpost_plan(location="", plan=None, device_type=None, parent=None, mou
         owner=get_owner(),
         parent=parent,
         mount_plan=mount_plan,
+        txt=txt,
         created_by=user,
         updated_by=user,
     )[0]
 
 
-def get_signpost_real(location="", device_type=None, signpost_plan=None, parent=None, mount_real=None):
+def get_signpost_real(
+    location="",
+    device_type=None,
+    signpost_plan=None,
+    parent=None,
+    mount_real=None,
+    txt=None,
+):
     user = get_user("test_user")
 
     return SignpostReal.objects.get_or_create(
@@ -240,6 +255,7 @@ def get_signpost_real(location="", device_type=None, signpost_plan=None, parent=
         owner=get_owner(),
         parent=parent,
         mount_real=mount_real,
+        txt=txt,
         created_by=user,
         updated_by=user,
     )[0]

--- a/traffic_control/tests/import_export/test_common.py
+++ b/traffic_control/tests/import_export/test_common.py
@@ -1,0 +1,40 @@
+from uuid import UUID
+
+import pytest
+
+from traffic_control.resources.common import UUIDWidget
+
+uuid = UUID("09e15054-c4f8-417e-9d21-8d0ff23ec743")
+uuid2 = UUID("4372e0ba-5bf2-46bf-ab33-6ffe7966d339")
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    (
+        (None, None),
+        ("", None),
+        (uuid, uuid),
+        (str(uuid2), uuid2),
+    ),
+)
+def test__uuid_widget__clean__valid(input, expected):
+    widget = UUIDWidget()
+    cleaned = widget.clean(input)
+    assert cleaned == expected
+
+
+@pytest.mark.parametrize(
+    "input",
+    (
+        0,
+        1,
+        True,
+        False,
+        "word",
+        "two words",
+    ),
+)
+def test__uuid_widget__clean__invalid(input):
+    widget = UUIDWidget()
+    with pytest.raises(ValueError):
+        widget.clean(input)

--- a/traffic_control/tests/import_export/test_signpost_import_export.py
+++ b/traffic_control/tests/import_export/test_signpost_import_export.py
@@ -1,8 +1,15 @@
+from uuid import UUID
+
 import pytest
 
 from traffic_control.models import SignpostPlan, SignpostReal
-from traffic_control.resources.signpost import SignpostPlanToRealTemplateResource, SignpostRealResource
+from traffic_control.resources.signpost import (
+    SignpostPlanResource,
+    SignpostPlanToRealTemplateResource,
+    SignpostRealResource,
+)
 from traffic_control.tests.factories import get_mount_plan, get_mount_real, get_signpost_plan, get_signpost_real
+from traffic_control.tests.import_export.utils import file_formats, get_import_dataset
 from traffic_control.tests.test_base_api import test_point_2
 
 
@@ -39,7 +46,11 @@ def test__signpost_real__import():
 @pytest.mark.parametrize("real_preexists", (True, False), ids=lambda x: "real_preexists" if x else "real_nonexists")
 @pytest.mark.django_db
 def test__signpost_plan_export_real_import(
-    has_mount_plan, has_mount_real, has_parent_plan, has_parent_real, real_preexists
+    has_mount_plan,
+    has_mount_real,
+    has_parent_plan,
+    has_parent_real,
+    real_preexists,
 ):
     """Test that a plan object can be exported as its real object (referencing to the plan)"""
 
@@ -62,8 +73,14 @@ def test__signpost_plan_export_real_import(
     else:
         assert real["mount_real__id"] is None
 
-    if has_parent_plan and has_parent_real:
-        assert real["parent__id"] == parent_real.id
+    if has_parent_plan:
+        if has_parent_real:
+            assert real["parent__id"] == parent_real.id
+        else:
+            if real_preexists:
+                assert real["parent__id"] == 1
+            else:
+                assert real["parent__id"] == 1
     else:
         assert real["parent__id"] is None
 
@@ -71,3 +88,138 @@ def test__signpost_plan_export_real_import(
         assert real["id"] == real_obj.id
     else:
         assert real["id"] is None
+
+
+@pytest.mark.django_db
+def test__signpost_plan_export_real_replacement_importable():
+    """
+    Test that a plan objects can be exported to real objects with parent-child id replacements
+    and the result is importable.
+    """
+
+    get_signpost_plan(location="POINT Z(1 0 0)")
+    plan_b = get_signpost_plan(location="POINT Z(2 0 0)")
+    get_signpost_plan(location="POINT Z(3 0 0)", parent=plan_b)
+    plan_d = get_signpost_plan(location="POINT Z(4 0 0)", parent=plan_b)
+    get_signpost_plan(location="POINT Z(5 0 0)", parent=plan_d)
+
+    exported_dataset = SignpostPlanToRealTemplateResource().export()
+    assert len(exported_dataset) == 5
+
+    import_result = SignpostRealResource().import_data(exported_dataset, raise_errors=False)
+    assert not import_result.has_errors()
+    assert SignpostReal.objects.all().count() == 5
+
+
+@pytest.mark.parametrize(
+    "parent_real_preexists",
+    (True, False),
+    ids=lambda x: "parent_real_preexists" if x else "parent_real_nonexists",
+)
+@pytest.mark.parametrize(
+    "child_real_preexists",
+    (True, False),
+    ids=lambda x: "child_real_preexists" if x else "child_real_nonexists",
+)
+@pytest.mark.django_db
+def test__signpost_plan_export_real_parent_and_child(parent_real_preexists, child_real_preexists):
+    plan_parent = get_signpost_plan()
+    plan_child = get_signpost_plan(parent=plan_parent)
+
+    if parent_real_preexists:
+        real_parent = get_signpost_real(signpost_plan=plan_parent)
+    else:
+        real_parent = None
+
+    if child_real_preexists:
+        real_child = get_signpost_real(signpost_plan=plan_child)
+    else:
+        real_child = None
+
+    exported_dataset = SignpostPlanToRealTemplateResource().export()
+    assert len(exported_dataset) == 2
+
+    assert exported_dataset["signpost_plan__id"] == [
+        plan_parent.id,
+        plan_child.id,
+    ]
+
+    if parent_real_preexists:
+        if child_real_preexists:
+            expected_ids = [
+                real_parent.id,
+                real_child.id,
+            ]
+            expected_parent_ids = [
+                None,
+                real_parent.id,
+            ]
+        else:
+            expected_ids = [
+                real_parent.id,
+                None,
+            ]
+            expected_parent_ids = [
+                None,
+                real_parent.id,
+            ]
+    else:
+        if child_real_preexists:
+            expected_ids = [
+                1,
+                real_child.id,
+            ]
+            expected_parent_ids = [
+                None,
+                1,
+            ]
+        else:
+            expected_ids = [
+                1,
+                None,
+            ]
+            expected_parent_ids = [None, 1]
+
+    assert exported_dataset["id"] == expected_ids
+    assert exported_dataset["parent__id"] == expected_parent_ids
+
+    # Import
+    import_result = SignpostRealResource().import_data(exported_dataset, raise_errors=False)
+    assert not import_result.has_errors()
+    assert SignpostReal.objects.all().count() == 2
+
+    imported_parent_real = SignpostReal.objects.get(signpost_plan=plan_parent)
+    imported_child_real = SignpostReal.objects.get(signpost_plan=plan_child)
+    assert imported_parent_real.parent_id is None
+    assert imported_child_real.parent_id == imported_parent_real.id
+    assert imported_parent_real.id != UUID(int=1)
+
+
+@pytest.mark.parametrize(
+    ("model", "resource", "factory"),
+    (
+        (SignpostReal, SignpostRealResource, get_signpost_real),
+        (SignpostPlan, SignpostPlanResource, get_signpost_plan),
+    ),
+)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db()
+def test__signpost__import__replace_parent_child_ids(model, resource, factory, format):
+    """Test that parent and child ids are replaced with the actual objects"""
+    parent = factory(txt="A")
+    child = factory(txt="B")
+
+    dataset = get_import_dataset(resource, format, delete_columns=["id", "parent__id"])
+    dataset = dataset.sort("txt")
+    dataset.append_col(["1", None], header="id")
+    dataset.append_col([None, "1"], header="parent__id")
+
+    model.objects.all().delete()
+    assert model.objects.count() == 0
+
+    result = resource().import_data(dataset, raise_errors=False, collect_failed_rows=True)
+    assert not result.has_errors()
+
+    imported_parent = model.objects.get(txt=parent.txt)
+    imported_child = model.objects.get(txt=child.txt)
+    assert imported_child.parent_id == imported_parent.id


### PR DESCRIPTION
When importing devices with child devices (i.e. signposts and furniture
signposts) a user can use non-UUID values in `id` and `parent__id`
columns to define parent-child relationships. Non-UUID values are
replaced with valid UUIDs.

Also when exporting device plans as reals template, `id` and
`parent__id` columns are prefilled with replacement values where needed.

Refs LIIK-493