### PR TITLE
Allow embed views to be embedded in <iframe> 

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-29 13:39+0300\n"
+"POT-Creation-Date: 2023-08-09 13:04+0300\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2094,6 +2094,10 @@ msgstr "Laitetyyppi '%(device_type)s' ei käytä rakenteista sisältöä"
 
 msgid "File not found."
 msgstr "Tiedostoa ei löytynyt."
+
+#, python-format
+msgid "Error: Could not find %(model_name)s with id %(id)s."
+msgstr "Virhe: %(model_name)s tunnisteella %(id)s ei löytynyt."
 
 msgid "last login"
 msgstr "kirjautunut viimeksi"

--- a/traffic_control/tests/test_embed.py
+++ b/traffic_control/tests/test_embed.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from django.urls import reverse
 
@@ -124,3 +126,11 @@ def test__embed__traffic_sign__context(
         assert context.get("mount_fields")[5][1] == mount.id
     else:
         assert context.get("mount_fields") == []
+
+
+@pytest.mark.parametrize("url_name", ("traffic-sign-plan-embed", "traffic-sign-real-embed"))
+@pytest.mark.django_db
+def test__embed__traffic_sign__not_found(client, url_name):
+    """Test that the embedded view returns 404 when the object is not found."""
+    response = client.get(reverse(url_name, kwargs={"pk": uuid.uuid4()}))
+    assert response.status_code == 404

--- a/traffic_control/tests/test_embed.py
+++ b/traffic_control/tests/test_embed.py
@@ -25,7 +25,7 @@ from traffic_control.tests.factories import (
 @pytest.mark.parametrize("has_additional_sign_device_types", (False, True))
 @pytest.mark.parametrize("has_mount", (False, True))
 @pytest.mark.django_db
-def test__embed__traffic_sign_plan_context(
+def test__embed__traffic_sign__context(
     settings,
     client,
     ts_factory,
@@ -89,6 +89,8 @@ def test__embed__traffic_sign_plan_context(
 
     response = client.get(reverse(url_name, kwargs={"pk": traffic_sign.id}))
     assert response.status_code == 200
+    # Must not deny frame-embedding embedded views
+    assert response.headers.get("x-frame-options") != "DENY"
 
     context = response.context
     assert context.get("object") == traffic_sign

--- a/traffic_control/views/embed.py
+++ b/traffic_control/views/embed.py
@@ -1,8 +1,11 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import DetailView
 
 from traffic_control.models import MountPlan, MountReal, TrafficSignPlan, TrafficSignReal
 
 
+@method_decorator(xframe_options_exempt, name="dispatch")
 class TrafficSignEmbed(DetailView):
     template_name = "embed/traffic_sign.html"
 


### PR DESCRIPTION
Django's `XFrameOptionsMiddleware` adds `x-frame-options: DENY` to all
HTTP request headers by default. We must set an exception for embedded
views.

Add simple 404 for embedded views.
With current settings, Django's default 404 page has
`x-frame-options: DENY`, so it's not handy for embedded views. But also
it's not explaining a user _what_ was not found.