### PR TITLE
Improve device import permissions with responsible entity

### DIFF
--- a/city_furniture/admin/__init__.py
+++ b/city_furniture/admin/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from city_furniture.admin.common import CityFurnitureColorAdmin, CityFurnitureDeviceTypeAdmin, CityFurnitureTargetAdmin
 from city_furniture.admin.furniture_signpost import (
     FurnitureSignpostPlanAdmin,

--- a/city_furniture/models/__init__.py
+++ b/city_furniture/models/__init__.py
@@ -1,9 +1,5 @@
-# flake8: noqa
 from .common import CityFurnitureColor, CityFurnitureDeviceType, CityFurnitureTarget
 from .furniture_signpost import (
-    CityFurnitureColor,
-    CityFurnitureDeviceType,
-    CityFurnitureTarget,
     FurnitureSignpostPlan,
     FurnitureSignpostPlanFile,
     FurnitureSignpostReal,

--- a/city_furniture/resources/__init__.py
+++ b/city_furniture/resources/__init__.py
@@ -1,0 +1,5 @@
+from city_furniture.resources.furniture_signpost import (
+    FurnitureSignpostPlanResource,
+    FurnitureSignpostPlanTemplateResource,
+    FurnitureSignpostRealResource,
+)

--- a/city_furniture/tests/factories.py
+++ b/city_furniture/tests/factories.py
@@ -11,13 +11,7 @@ from city_furniture.models import (
     FurnitureSignpostReal,
     FurnitureSignpostRealOperation,
 )
-from traffic_control.tests.factories import (
-    get_mount_type,
-    get_operation_type,
-    get_owner,
-    get_responsible_entity,
-    get_user,
-)
+from traffic_control.tests.factories import get_mount_type, get_operation_type, get_owner, get_user
 from traffic_control.tests.test_base_api_3d import test_point_3d
 
 
@@ -66,6 +60,7 @@ def get_city_furniture_device_type(
 
 def get_furniture_signpost_plan(
     location=None,
+    responsible_entity=None,
     owner=None,
     device_type=None,
     parent=None,
@@ -88,7 +83,7 @@ def get_furniture_signpost_plan(
         mount_plan=mount_plan,
         source_name="Some_source",
         source_id=uuid.uuid4(),
-        responsible_entity=get_responsible_entity(),
+        responsible_entity=responsible_entity,
         parent=parent,
         created_by=user,
         updated_by=user,
@@ -98,6 +93,7 @@ def get_furniture_signpost_plan(
 
 def get_furniture_signpost_real(
     location=None,
+    responsible_entity=None,
     owner=None,
     device_type=None,
     furniture_signpost_plan=None,
@@ -125,7 +121,7 @@ def get_furniture_signpost_real(
         installation_date=datetime.date(2020, 1, 20),
         source_name="Some_source",
         source_id=uuid.uuid4(),
-        responsible_entity=get_responsible_entity(),
+        responsible_entity=responsible_entity,
         parent=parent,
         created_by=user,
         updated_by=user,

--- a/city_furniture/tests/test_furniture_signpost_api.py
+++ b/city_furniture/tests/test_furniture_signpost_api.py
@@ -20,7 +20,7 @@ from traffic_control.tests.factories import (
     get_api_client,
     get_operation_type,
     get_owner,
-    get_responsible_entity,
+    get_responsible_entity_project,
     get_user,
 )
 from traffic_control.tests.test_base_api_3d import test_point_2_3d, test_point_3d
@@ -382,7 +382,7 @@ def test__furniture_signpost_real__responsible_entity_permission__create(add_to_
     user = get_user(admin=False, bypass_operational_area=True)
     user.user_permissions.add(Permission.objects.get(codename="add_furnituresignpostreal"))
     client = get_api_client(user=user)
-    responsible_entity = get_responsible_entity()
+    responsible_entity = get_responsible_entity_project()
     data = {
         "location": str(test_point_3d),
         "owner": get_owner().pk,
@@ -407,7 +407,7 @@ def test__furniture_signpost_real__responsible_entity_permission__delete(add_to_
     user = get_user(admin=False, bypass_operational_area=True)
     user.user_permissions.add(Permission.objects.get(codename="delete_furnituresignpostreal"))
     client = get_api_client(user=user)
-    responsible_entity = get_responsible_entity()
+    responsible_entity = get_responsible_entity_project()
     instance = get_furniture_signpost_real(responsible_entity=responsible_entity)
 
     if add_to_responsible_entity:
@@ -431,7 +431,7 @@ def test__furniture_signpost_real__create__responsible_entity_permission__group(
     group = Group.objects.create(name="test group")
     user.groups.add(group)
     client = get_api_client(user=user)
-    responsible_entity = get_responsible_entity()
+    responsible_entity = get_responsible_entity_project()
     data = {
         "location": str(test_point_3d),
         "owner": get_owner().pk,

--- a/city_furniture/tests/test_furniture_signpost_api.py
+++ b/city_furniture/tests/test_furniture_signpost_api.py
@@ -407,7 +407,8 @@ def test__furniture_signpost_real__responsible_entity_permission__delete(add_to_
     user = get_user(admin=False, bypass_operational_area=True)
     user.user_permissions.add(Permission.objects.get(codename="delete_furnituresignpostreal"))
     client = get_api_client(user=user)
-    instance = get_furniture_signpost_real()
+    responsible_entity = get_responsible_entity()
+    instance = get_furniture_signpost_real(responsible_entity=responsible_entity)
 
     if add_to_responsible_entity:
         user.responsible_entities.add(instance.responsible_entity)

--- a/city_furniture/tests/test_furniture_signpost_import_export.py
+++ b/city_furniture/tests/test_furniture_signpost_import_export.py
@@ -217,25 +217,6 @@ def test__furniture_signpost_plan_export_real_parent_and_child(parent_real_preex
 
 
 @pytest.mark.django_db
-def test__furniture_signpost_real__import__responsible_entity_permission():
-    get_furniture_signpost_real(responsible_entity=get_responsible_entity_project())
-    dataset = FurnitureSignpostRealResource().export()
-
-    user = get_user()
-    with pytest.raises(ValidationError):
-        FurnitureSignpostRealResource().import_data(dataset, raise_errors=True, user=user)
-
-    user.responsible_entities.add(ResponsibleEntity.objects.get(organization_level=OrganizationLevel.PROJECT))
-    result = FurnitureSignpostRealResource().import_data(dataset, raise_errors=True, user=user)
-    assert not result.has_errors()
-
-    user.responsible_entities.clear()
-    user.responsible_entities.add(ResponsibleEntity.objects.get(organization_level=OrganizationLevel.DIVISION))
-    result = FurnitureSignpostRealResource().import_data(dataset, raise_errors=True, user=user)
-    assert not result.has_errors()
-
-
-@pytest.mark.django_db
 def test__furniture_signpost_real__import__responsible_entity_permission__group():
     get_furniture_signpost_real(responsible_entity=get_responsible_entity_project())
     dataset = FurnitureSignpostRealResource().export()

--- a/city_furniture/tests/test_furniture_signpost_import_export.py
+++ b/city_furniture/tests/test_furniture_signpost_import_export.py
@@ -13,7 +13,7 @@ from city_furniture.resources.furniture_signpost import (
 from city_furniture.tests.factories import get_furniture_signpost_plan, get_furniture_signpost_real
 from traffic_control.enums import OrganizationLevel
 from traffic_control.models import GroupResponsibleEntity, ResponsibleEntity
-from traffic_control.tests.factories import get_mount_plan, get_mount_real, get_responsible_entity, get_user
+from traffic_control.tests.factories import get_mount_plan, get_mount_real, get_responsible_entity_project, get_user
 from traffic_control.tests.import_export.utils import file_formats, get_import_dataset
 from traffic_control.tests.test_base_api import test_point_2
 
@@ -218,7 +218,7 @@ def test__furniture_signpost_plan_export_real_parent_and_child(parent_real_preex
 
 @pytest.mark.django_db
 def test__furniture_signpost_real__import__responsible_entity_permission():
-    get_furniture_signpost_real(responsible_entity=get_responsible_entity())
+    get_furniture_signpost_real(responsible_entity=get_responsible_entity_project())
     dataset = FurnitureSignpostRealResource().export()
 
     user = get_user()
@@ -237,7 +237,7 @@ def test__furniture_signpost_real__import__responsible_entity_permission():
 
 @pytest.mark.django_db
 def test__furniture_signpost_real__import__responsible_entity_permission__group():
-    get_furniture_signpost_real(responsible_entity=get_responsible_entity())
+    get_furniture_signpost_real(responsible_entity=get_responsible_entity_project())
     dataset = FurnitureSignpostRealResource().export()
 
     user = get_user()

--- a/city_furniture/tests/test_furniture_signpost_import_export.py
+++ b/city_furniture/tests/test_furniture_signpost_import_export.py
@@ -13,7 +13,7 @@ from city_furniture.resources.furniture_signpost import (
 from city_furniture.tests.factories import get_furniture_signpost_plan, get_furniture_signpost_real
 from traffic_control.enums import OrganizationLevel
 from traffic_control.models import GroupResponsibleEntity, ResponsibleEntity
-from traffic_control.tests.factories import get_mount_plan, get_mount_real, get_user
+from traffic_control.tests.factories import get_mount_plan, get_mount_real, get_responsible_entity, get_user
 from traffic_control.tests.import_export.utils import file_formats, get_import_dataset
 from traffic_control.tests.test_base_api import test_point_2
 
@@ -218,7 +218,7 @@ def test__furniture_signpost_plan_export_real_parent_and_child(parent_real_preex
 
 @pytest.mark.django_db
 def test__furniture_signpost_real__import__responsible_entity_permission():
-    get_furniture_signpost_real()
+    get_furniture_signpost_real(responsible_entity=get_responsible_entity())
     dataset = FurnitureSignpostRealResource().export()
 
     user = get_user()
@@ -237,7 +237,7 @@ def test__furniture_signpost_real__import__responsible_entity_permission():
 
 @pytest.mark.django_db
 def test__furniture_signpost_real__import__responsible_entity_permission__group():
-    get_furniture_signpost_real()
+    get_furniture_signpost_real(responsible_entity=get_responsible_entity())
     dataset = FurnitureSignpostRealResource().export()
 
     user = get_user()

--- a/city_furniture/views/wfs/__init__.py
+++ b/city_furniture/views/wfs/__init__.py
@@ -1,2 +1,1 @@
-# flake8: noqa
 from .furniture_signpost import FurnitureSignpostPlanFeatureType, FurnitureSignpostRealFeatureType

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-18 13:18+0300\n"
+"POT-Creation-Date: 2023-08-29 17:07+0300\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2083,6 +2083,33 @@ msgid ""
 msgstr ""
 "Arvo '%(value)s' ei kelpaa. Kelvolliset arvot ovat %(enum_values)s "
 "(%(enum)s)."
+
+msgid ""
+"You do not have a permission to modify devices without a responsible entity."
+msgstr "Sinulla ei ole oikeutta muokata laitteita ilman vastuutahoa."
+
+#, python-format
+msgid ""
+"You do not have a permission to modify devices of responsible entity "
+"'%(responsible_entity)s'."
+msgstr ""
+"Sinulla ei ole oikeutta muokata vastuutahon '%(responsible_entity)s' "
+"laitteita."
+
+msgid ""
+"You do not have a permission to create devices without a responsible entity "
+"or to remove responsible entity from existing devices."
+msgstr ""
+"Sinulla ei ole oikeutta luoda laitteita ilman vastuutahoa tai poistaa "
+"vastuutahoa olemassa olevista laitteista."
+
+#, python-format
+msgid ""
+"You do not have a permission to create or modify devices with given "
+"responsible entity (%(responsible_entity)s)."
+msgstr ""
+"Sinulla ei ole oikeutta luoda tai muokata laitteita annetulla vastuutaholla "
+"(%(responsible_entity)s)."
 
 msgid "Export template"
 msgstr "Vie malli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ use_parentheses = true
 exclude = ["migrations", "venv"]
 max-line-length = 120
 max-complexity = 10
-
+per-file-ignores = ["**/__init__.py:F401"]
 
 [tool.djlint]
 ignore = "T003,H023,H030,H031"

--- a/traffic_control/admin/__init__.py
+++ b/traffic_control/admin/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from traffic_control.admin.additional_sign import AdditionalSignPlanAdmin, AdditionalSignRealAdmin
 from traffic_control.admin.affect_area import CoverageAreaAdmin, CoverageAreaCategoryAdmin
 from traffic_control.admin.audit_log import AuditLogHistoryAdmin

--- a/traffic_control/admin/additional_sign.py
+++ b/traffic_control/admin/additional_sign.py
@@ -151,6 +151,7 @@ class AdditionalSignPlanAdmin(
 
 @admin.register(AdditionalSignReal)
 class AdditionalSignRealAdmin(
+    ResponsibleEntityPermissionAdminMixin,
     DeviceComparisonAdminMixin,
     EnumChoiceValueDisplayAdminMixin,
     SoftDeleteAdminMixin,

--- a/traffic_control/models/__init__.py
+++ b/traffic_control/models/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from traffic_control.models.additional_sign import AdditionalSignPlan, AdditionalSignReal, AdditionalSignRealOperation
 from traffic_control.models.affect_area import CoverageArea, CoverageAreaCategory
 from traffic_control.models.barrier import (

--- a/traffic_control/resources/__init__.py
+++ b/traffic_control/resources/__init__.py
@@ -1,0 +1,31 @@
+from traffic_control.resources.additional_sign import (
+    AdditionalSignPlanResource,
+    AdditionalSignPlanToRealTemplateResource,
+    AdditionalSignRealResource,
+)
+from traffic_control.resources.barrier import (
+    BarrierPlanResource,
+    BarrierPlanToRealTemplateResource,
+    BarrierRealResource,
+)
+from traffic_control.resources.mount import MountPlanResource, MountPlanToRealTemplateResource, MountRealResource
+from traffic_control.resources.road_marking import (
+    RoadMarkingPlanResource,
+    RoadMarkingPlanToRealTemplateResource,
+    RoadMarkingRealResource,
+)
+from traffic_control.resources.signpost import (
+    SignpostPlanResource,
+    SignpostPlanToRealTemplateResource,
+    SignpostRealResource,
+)
+from traffic_control.resources.traffic_light import (
+    TrafficLightPlanResource,
+    TrafficLightPlanToRealTemplateResource,
+    TrafficLightRealResource,
+)
+from traffic_control.resources.traffic_sign import (
+    TrafficSignPlanResource,
+    TrafficSignPlanToRealTemplateResource,
+    TrafficSignRealResource,
+)

--- a/traffic_control/resources/mount.py
+++ b/traffic_control/resources/mount.py
@@ -27,6 +27,7 @@ class AbstractMountResource(ResponsibleEntityPermissionImportMixin, GenericDevic
         column_name="portal_type__id",
         widget=ForeignKeyWidget(PortalType, "id"),
     )
+    base = Field(default="")
 
     class Meta(GenericDeviceBaseResource.Meta):
         common_fields = (

--- a/traffic_control/tests/factories.py
+++ b/traffic_control/tests/factories.py
@@ -89,7 +89,12 @@ def get_plan(location=test_multi_polygon, name="Test plan", derive_location=Fals
     )[0]
 
 
-def get_barrier_plan(location="", plan=None, device_type=None) -> BarrierPlan:
+def get_barrier_plan(
+    location="",
+    plan=None,
+    device_type=None,
+    responsible_entity=None,
+) -> BarrierPlan:
     user = get_user("test_user")
     return BarrierPlan.objects.get_or_create(
         device_type=device_type,
@@ -101,12 +106,17 @@ def get_barrier_plan(location="", plan=None, device_type=None) -> BarrierPlan:
         road_name="Testingroad",
         plan=plan,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         created_by=user,
         updated_by=user,
     )[0]
 
 
-def get_barrier_real(location="", device_type=None) -> BarrierReal:
+def get_barrier_real(
+    location="",
+    device_type=None,
+    responsible_entity=None,
+) -> BarrierReal:
     user = get_user("test_user")
 
     return BarrierReal.objects.create(
@@ -120,6 +130,7 @@ def get_barrier_real(location="", device_type=None) -> BarrierReal:
         connection_type=ConnectionType.OPEN_OUT,
         road_name="Testingroad",
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         created_by=user,
         updated_by=user,
     )
@@ -141,7 +152,7 @@ def get_portal_type(
     )[0]
 
 
-def get_mount_plan(location="", plan=None) -> MountPlan:
+def get_mount_plan(location="", plan=None, responsible_entity=None) -> MountPlan:
     user = get_user("test_user")
 
     return MountPlan.objects.get_or_create(
@@ -150,12 +161,13 @@ def get_mount_plan(location="", plan=None) -> MountPlan:
         lifecycle=Lifecycle.ACTIVE,
         plan=plan,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         created_by=user,
         updated_by=user,
     )[0]
 
 
-def get_mount_real(location="") -> MountReal:
+def get_mount_real(location="", responsible_entity=None) -> MountReal:
     user = get_user("test_user")
 
     return MountReal.objects.get_or_create(
@@ -165,6 +177,7 @@ def get_mount_real(location="") -> MountReal:
         installation_date=datetime.date(2020, 1, 1),
         lifecycle=Lifecycle.ACTIVE,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         created_by=user,
         updated_by=user,
     )[0]
@@ -175,6 +188,7 @@ def get_road_marking_plan(
     plan=None,
     device_type=None,
     traffic_sign_plan=None,
+    responsible_entity=None,
 ) -> RoadMarkingPlan:
     user = get_user("test_user")
 
@@ -190,6 +204,7 @@ def get_road_marking_plan(
         road_name="Testingroad",
         plan=plan,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         traffic_sign_plan=traffic_sign_plan,
         created_by=user,
         updated_by=user,
@@ -201,6 +216,7 @@ def get_road_marking_real(
     device_type=None,
     road_marking_plan=None,
     traffic_sign_real=None,
+    responsible_entity=None,
 ) -> RoadMarkingReal:
     user = get_user("test_user")
 
@@ -217,6 +233,7 @@ def get_road_marking_real(
         is_raised=False,
         road_name="Testingroad",
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         traffic_sign_real=traffic_sign_real,
         created_by=user,
         updated_by=user,
@@ -230,6 +247,7 @@ def get_signpost_plan(
     parent=None,
     mount_plan=None,
     txt=None,
+    responsible_entity=None,
 ) -> SignpostPlan:
     user = get_user("test_user")
 
@@ -239,6 +257,7 @@ def get_signpost_plan(
         lifecycle=Lifecycle.ACTIVE,
         plan=plan,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         parent=parent,
         mount_plan=mount_plan,
         txt=txt,
@@ -254,6 +273,7 @@ def get_signpost_real(
     parent=None,
     mount_real=None,
     txt=None,
+    responsible_entity=None,
 ) -> SignpostReal:
     user = get_user("test_user")
 
@@ -264,6 +284,7 @@ def get_signpost_real(
         installation_date=datetime.date(2020, 1, 1),
         lifecycle=Lifecycle.ACTIVE,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         parent=parent,
         mount_real=mount_real,
         txt=txt,
@@ -277,6 +298,7 @@ def get_traffic_light_plan(
     plan=None,
     device_type=None,
     mount_plan=None,
+    responsible_entity=None,
 ) -> TrafficLightPlan:
     user = get_user("test_user")
 
@@ -291,6 +313,7 @@ def get_traffic_light_plan(
         sound_beacon=TrafficLightSoundBeaconValue.YES,
         plan=plan,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         created_by=user,
         updated_by=user,
     )[0]
@@ -301,6 +324,7 @@ def get_traffic_light_real(
     device_type=None,
     traffic_light_plan=None,
     mount_real=None,
+    responsible_entity=None,
 ) -> TrafficLightReal:
     user = get_user("test_user")
 
@@ -316,6 +340,7 @@ def get_traffic_light_real(
         road_name="Testingroad",
         sound_beacon=TrafficLightSoundBeaconValue.YES,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         created_by=user,
         updated_by=user,
     )[0]
@@ -348,6 +373,7 @@ def get_traffic_sign_plan(
     plan=None,
     device_type=None,
     mount_plan=None,
+    responsible_entity=None,
 ) -> TrafficSignPlan:
     user = get_user("test_user")
 
@@ -357,6 +383,7 @@ def get_traffic_sign_plan(
         lifecycle=Lifecycle.ACTIVE,
         plan=plan,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         mount_plan=mount_plan,
         created_by=user,
         updated_by=user,
@@ -368,6 +395,7 @@ def get_traffic_sign_real(
     device_type=None,
     traffic_sign_plan=None,
     mount_real=None,
+    responsible_entity=None,
 ) -> TrafficSignReal:
     user = get_user("test_user")
 
@@ -378,6 +406,7 @@ def get_traffic_sign_real(
         installation_date=datetime.date(2020, 1, 1),
         lifecycle=Lifecycle.ACTIVE,
         owner=get_owner(),
+        responsible_entity=responsible_entity,
         mount_real=mount_real,
         created_by=user,
         updated_by=user,
@@ -393,6 +422,7 @@ def get_additional_sign_plan(
     plan=None,
     content_s=None,
     order=None,
+    responsible_entity=None,
 ) -> AdditionalSignPlan:
     user = get_user("test_user")
     owner = owner or get_owner()
@@ -411,6 +441,7 @@ def get_additional_sign_plan(
         location=location,
         device_type=device_type,
         owner=owner,
+        responsible_entity=responsible_entity,
         plan=plan,
         created_by=user,
         updated_by=user,
@@ -430,6 +461,7 @@ def get_additional_sign_real(
     owner=None,
     content_s=None,
     order=None,
+    responsible_entity=None,
 ) -> AdditionalSignReal:
     user = get_user("test_user")
     owner = owner or get_owner()
@@ -449,6 +481,7 @@ def get_additional_sign_real(
         location=location,
         device_type=device_type,
         owner=owner,
+        responsible_entity=responsible_entity,
         created_by=user,
         updated_by=user,
         content_s=content_s,

--- a/traffic_control/tests/factories.py
+++ b/traffic_control/tests/factories.py
@@ -615,21 +615,32 @@ def add_traffic_light_real_operation(
     )
 
 
-def get_responsible_entity(name="ABC-123") -> ResponsibleEntity:
-    division = ResponsibleEntity.objects.get_or_create(
-        name="KYMP",
+def get_responsible_entity_division(name="DIVISION") -> ResponsibleEntity:
+    return ResponsibleEntity.objects.get_or_create(
+        name=name,
         defaults=dict(organization_level=OrganizationLevel.DIVISION),
     )[0]
-    service = ResponsibleEntity.objects.get_or_create(
-        name="Yleiset alueet",
-        defaults=dict(parent=division, organization_level=OrganizationLevel.SERVICE),
-    )[0]
-    unit = ResponsibleEntity.objects.get_or_create(
-        name="Unit Name",
-        defaults=dict(parent=service, organization_level=OrganizationLevel.UNIT),
-    )[0]
-    project = ResponsibleEntity.objects.get_or_create(
+
+
+def get_responsible_entity_service(name="SERVICE") -> ResponsibleEntity:
+    parent = get_responsible_entity_division()
+    return ResponsibleEntity.objects.get_or_create(
         name=name,
-        defaults=dict(parent=unit, organization_level=OrganizationLevel.PROJECT),
+        defaults=dict(parent=parent, organization_level=OrganizationLevel.SERVICE),
     )[0]
-    return project
+
+
+def get_responsible_entity_unit(name="UNIT") -> ResponsibleEntity:
+    parent = get_responsible_entity_service()
+    return ResponsibleEntity.objects.get_or_create(
+        name=name,
+        defaults=dict(parent=parent, organization_level=OrganizationLevel.UNIT),
+    )[0]
+
+
+def get_responsible_entity_project(name="PROJECT") -> ResponsibleEntity:
+    parent = get_responsible_entity_unit()
+    return ResponsibleEntity.objects.get_or_create(
+        name=name,
+        defaults=dict(parent=parent, organization_level=OrganizationLevel.PROJECT),
+    )[0]

--- a/traffic_control/tests/import_export/test_device_responsible_entity_import_export.py
+++ b/traffic_control/tests/import_export/test_device_responsible_entity_import_export.py
@@ -1,0 +1,411 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from city_furniture.models import FurnitureSignpostPlan, FurnitureSignpostReal
+from city_furniture.resources import FurnitureSignpostPlanResource, FurnitureSignpostRealResource
+from city_furniture.tests.factories import get_furniture_signpost_plan, get_furniture_signpost_real
+from traffic_control.models import (
+    AdditionalSignPlan,
+    AdditionalSignReal,
+    BarrierPlan,
+    BarrierReal,
+    MountPlan,
+    MountReal,
+    RoadMarkingPlan,
+    RoadMarkingReal,
+    SignpostPlan,
+    SignpostReal,
+    TrafficLightPlan,
+    TrafficLightReal,
+    TrafficSignPlan,
+    TrafficSignReal,
+)
+from traffic_control.resources import (
+    AdditionalSignPlanResource,
+    AdditionalSignRealResource,
+    BarrierPlanResource,
+    BarrierRealResource,
+    MountPlanResource,
+    MountRealResource,
+    RoadMarkingPlanResource,
+    RoadMarkingRealResource,
+    SignpostPlanResource,
+    SignpostRealResource,
+    TrafficLightPlanResource,
+    TrafficLightRealResource,
+    TrafficSignPlanResource,
+    TrafficSignRealResource,
+)
+from traffic_control.tests.factories import (
+    get_additional_sign_plan,
+    get_additional_sign_real,
+    get_barrier_plan,
+    get_barrier_real,
+    get_mount_plan,
+    get_mount_real,
+    get_responsible_entity_project,
+    get_road_marking_plan,
+    get_road_marking_real,
+    get_signpost_plan,
+    get_signpost_real,
+    get_traffic_light_plan,
+    get_traffic_light_real,
+    get_traffic_sign_plan,
+    get_traffic_sign_real,
+    get_user,
+)
+from traffic_control.tests.import_export.utils import file_formats, get_import_dataset
+
+_models_resources_factories = (
+    (FurnitureSignpostPlan, FurnitureSignpostPlanResource, get_furniture_signpost_plan),
+    (FurnitureSignpostReal, FurnitureSignpostRealResource, get_furniture_signpost_real),
+    (AdditionalSignPlan, AdditionalSignPlanResource, get_additional_sign_plan),
+    (AdditionalSignReal, AdditionalSignRealResource, get_additional_sign_real),
+    (BarrierPlan, BarrierPlanResource, get_barrier_plan),
+    (BarrierReal, BarrierRealResource, get_barrier_real),
+    (MountPlan, MountPlanResource, get_mount_plan),
+    (MountReal, MountRealResource, get_mount_real),
+    (RoadMarkingPlan, RoadMarkingPlanResource, get_road_marking_plan),
+    (RoadMarkingReal, RoadMarkingRealResource, get_road_marking_real),
+    (SignpostPlan, SignpostPlanResource, get_signpost_plan),
+    (SignpostReal, SignpostRealResource, get_signpost_real),
+    (TrafficLightPlan, TrafficLightPlanResource, get_traffic_light_plan),
+    (TrafficLightReal, TrafficLightRealResource, get_traffic_light_real),
+    (TrafficSignPlan, TrafficSignPlanResource, get_traffic_sign_plan),
+    (TrafficSignReal, TrafficSignRealResource, get_traffic_sign_real),
+)
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_cannot_import_without_re(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User cannot import a new device because they don't belong to the responsible entity"""
+    re_project = get_responsible_entity_project()
+
+    factory(responsible_entity=re_project)
+    dataset = get_import_dataset(resource, format=format, delete_columns=["id"])
+    model.objects.all().delete()
+
+    user = get_user()
+
+    with pytest.raises(ValidationError):
+        resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.all().count() == 0
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_can_import_to_their_re(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User can import a new device because they belong to the same responsible entity"""
+    re_project = get_responsible_entity_project()
+
+    user = get_user()
+    user.responsible_entities.add(re_project)
+
+    factory(responsible_entity=re_project)
+    dataset = get_import_dataset(resource, format=format, delete_columns=["id"])
+    model.objects.all().delete()
+
+    result = resource().import_data(dataset, raise_errors=True, user=user)
+    assert not result.has_errors()
+    assert model.objects.all().count() == 1
+    assert model.objects.first().responsible_entity == re_project
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_can_import_to_child_re(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User can import a new device because they belong to a higher level responsible entity"""
+    re_project = get_responsible_entity_project()
+    re_parent = re_project.parent
+    assert re_parent is not None
+
+    user = get_user()
+    user.responsible_entities.add(re_parent)
+
+    factory(responsible_entity=re_project)
+    dataset = get_import_dataset(resource, format=format, delete_columns=["id"])
+    model.objects.all().delete()
+
+    result = resource().import_data(dataset, raise_errors=True, user=user)
+    assert not result.has_errors()
+    assert model.objects.all().count() == 1
+    assert model.objects.first().responsible_entity == re_project
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_cannot_import_new_devices_to_another_re(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User cannot import a new device of another responsible entity"""
+    re_project = get_responsible_entity_project()
+    another_re_project = get_responsible_entity_project(name="Another project")
+
+    user = get_user()
+    user.responsible_entities.add(re_project)
+
+    factory(responsible_entity=another_re_project)
+    dataset = get_import_dataset(resource, format=format, delete_columns=["id"])
+    model.objects.all().delete()
+
+    with pytest.raises(ValidationError):
+        resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.all().count() == 0
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_cannot_move_device_from_another_re_to_theirs(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User cannot move a device from another responsible entity to theirs using import"""
+    re_project = get_responsible_entity_project()
+    another_re_project = get_responsible_entity_project(name="Another project")
+
+    user = get_user()
+    user.responsible_entities.add(re_project)
+
+    device = factory(responsible_entity=re_project)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = another_re_project
+    device.save()
+
+    with pytest.raises(ValidationError):
+        resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.filter(responsible_entity=re_project).count() == 0
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_cannot_move_device_from_non_re_to_theirs(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User cannot move a device from non-responsible entity to theirs using import"""
+    re_project = get_responsible_entity_project()
+
+    user = get_user()
+    user.responsible_entities.add(re_project)
+
+    device = factory(responsible_entity=re_project)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = None
+    device.save()
+
+    with pytest.raises(ValidationError):
+        resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.filter(responsible_entity=re_project).count() == 0
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_cannot_move_device_from_non_re_to_non_theirs(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User cannot move a device from non-responsible entity to another using import"""
+    re_project = get_responsible_entity_project()
+    another_re_project = get_responsible_entity_project(name="Another project")
+
+    user = get_user()
+    user.responsible_entities.add(re_project)
+
+    device = factory(responsible_entity=another_re_project)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = None
+    device.save()
+
+    with pytest.raises(ValidationError):
+        resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.filter(responsible_entity=another_re_project).count() == 0
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_cannot_remove_device_from_their_re(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User cannot remove a device from their responsible entity using import"""
+    re_project = get_responsible_entity_project()
+
+    user = get_user()
+    user.responsible_entities.add(re_project)
+
+    device = factory(responsible_entity=None)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = re_project
+    device.save()
+
+    with pytest.raises(ValidationError):
+        resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.filter(responsible_entity=re_project).count() == 1
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_cannot_remove_device_from_another_re(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User cannot remove a device from a responsible entity that they don't belong in using import"""
+    re_project = get_responsible_entity_project()
+    another_re_project = get_responsible_entity_project(name="Another project")
+
+    user = get_user()
+    user.responsible_entities.add(re_project)
+
+    device = factory(responsible_entity=None)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = another_re_project
+    device.save()
+
+    with pytest.raises(ValidationError):
+        resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.filter(responsible_entity=another_re_project).count() == 1
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_cannot_move_device_to_their_parent_re(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User cannot move a device from their responsible entity their parent responsible entity using import"""
+    re_project = get_responsible_entity_project()
+    re_parent = re_project.parent
+    assert re_parent is not None
+
+    user = get_user()
+    user.responsible_entities.add(re_project)
+
+    device = factory(responsible_entity=re_parent)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = re_project
+    device.save()
+
+    with pytest.raises(ValidationError):
+        resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.filter(responsible_entity=re_parent).count() == 0
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_can_move_device_from_child_re_to_another(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User can move a device from their child responsible entity to another child using import"""
+    re_project_1 = get_responsible_entity_project(name="Project 1")
+    re_project_2 = get_responsible_entity_project(name="Project 2")
+    re_parent = re_project_1.parent
+    assert re_parent is not None
+    assert re_parent == re_project_2.parent
+
+    user = get_user()
+    user.responsible_entities.add(re_parent)
+
+    device = factory(responsible_entity=re_project_2)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = re_project_1
+    device.save()
+
+    resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.get(id=device.id).responsible_entity == re_project_2
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_can_move_device_from_child_to_theirs(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User can move a device from their child responsible entity to their responsible entity using import"""
+    re_project = get_responsible_entity_project()
+    re_parent = re_project.parent
+    assert re_parent is not None
+
+    user = get_user()
+    user.responsible_entities.add(re_parent)
+
+    device = factory(responsible_entity=re_parent)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = re_project
+    device.save()
+
+    resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.get(id=device.id).responsible_entity == re_parent
+
+
+@pytest.mark.parametrize(("model", "resource", "factory"), _models_resources_factories)
+@pytest.mark.parametrize("format", file_formats)
+@pytest.mark.django_db
+def test__import__device__responsible_entity__user_can_move_device_from_theirs_to_child(
+    model,
+    resource,
+    factory,
+    format,
+):
+    """User can move a device from their responsible entity to a child using import"""
+    re_project = get_responsible_entity_project()
+    re_parent = re_project.parent
+    assert re_parent is not None
+
+    user = get_user()
+    user.responsible_entities.add(re_parent)
+
+    device = factory(responsible_entity=re_project)
+    dataset = get_import_dataset(resource, format=format)
+    device.responsible_entity = re_parent
+    device.save()
+
+    resource().import_data(dataset, raise_errors=True, user=user)
+    assert model.objects.get(id=device.id).responsible_entity == re_project

--- a/traffic_control/tests/test_responsible_entity_api.py
+++ b/traffic_control/tests/test_responsible_entity_api.py
@@ -7,7 +7,7 @@ from rest_framework import status
 
 from traffic_control.enums import OrganizationLevel
 from traffic_control.models import ResponsibleEntity
-from traffic_control.tests.factories import get_api_client, get_responsible_entity, get_user
+from traffic_control.tests.factories import get_api_client, get_responsible_entity_project, get_user
 
 
 # Read
@@ -15,7 +15,7 @@ from traffic_control.tests.factories import get_api_client, get_responsible_enti
 def test__responsible_entity__list():
     client = get_api_client()
     for name in ["foo", "bar", "baz"]:
-        get_responsible_entity(name=name)
+        get_responsible_entity_project(name=name)
 
     response = client.get(reverse("v1:responsibleentity-list"))
     response_data = response.json()
@@ -30,7 +30,7 @@ def test__responsible_entity__list():
 @pytest.mark.django_db
 def test__responsible_entity__detail():
     client = get_api_client()
-    obj = get_responsible_entity()
+    obj = get_responsible_entity_project()
 
     response = client.get(reverse("v1:responsibleentity-detail", kwargs={"pk": obj.pk}))
     response_data = response.json()
@@ -94,7 +94,7 @@ def test__responsible_entity__update(admin_user):
     is successful when content is not defined. Old content should be deleted.
     """
     client = get_api_client(user=get_user(admin=admin_user))
-    obj = get_responsible_entity(name="ORIGINAL_NAME")
+    obj = get_responsible_entity_project(name="ORIGINAL_NAME")
     data = {"name": "UPDATED_NAME"}
 
     response = client.put(reverse("v1:responsibleentity-detail", kwargs={"pk": obj.pk}), data=data)
@@ -116,7 +116,7 @@ def test__responsible_entity__update(admin_user):
 def test__responsible_entity__delete(admin_user):
     user = get_user(admin=admin_user)
     client = get_api_client(user=user)
-    obj = get_responsible_entity()
+    obj = get_responsible_entity_project()
 
     response = client.delete(reverse("v1:responsibleentity-detail", kwargs={"pk": obj.pk}))
 
@@ -148,7 +148,7 @@ def test__responsible_entity__anonymous_user(method, expected_status, view_type)
     Test that for unauthorized user the API responses 401 unauthorized, but OK for safe methods.
     """
     client = get_api_client(user=None)
-    responsible_entity = get_responsible_entity(name="Responsible 1")
+    responsible_entity = get_responsible_entity_project(name="Responsible 1")
     kwargs = {"pk": responsible_entity.pk} if view_type == "detail" else None
     resource_path = reverse(f"v1:responsibleentity-{view_type}", kwargs=kwargs)
     data = {"name": "Responsible 2"}

--- a/traffic_control/tests/test_responsible_entity_api_permission.py
+++ b/traffic_control/tests/test_responsible_entity_api_permission.py
@@ -8,7 +8,7 @@ from traffic_control.enums import Lifecycle
 from traffic_control.tests.factories import (
     get_api_client,
     get_owner,
-    get_responsible_entity,
+    get_responsible_entity_project,
     get_traffic_control_device_type,
     get_user,
 )
@@ -44,7 +44,7 @@ def test__api_responsible_area_permission__create(model, add_to_responsible_enti
     user = get_user(bypass_operational_area=True)
     perms = Permission.objects.filter(codename__contains=model.lower())
     user.user_permissions.add(*perms)
-    responsible_entity = get_responsible_entity()
+    responsible_entity = get_responsible_entity_project()
 
     data = {
         "location": str(test_point_3d),

--- a/traffic_control/views/wfs/__init__.py
+++ b/traffic_control/views/wfs/__init__.py
@@ -1,3 +1,2 @@
-# flake8: noqa
 from .additional_sign import AdditionalSignPlanFeatureType, AdditionalSignRealFeatureType
 from .traffic_sign import TrafficSignPlanFeatureType, TrafficSignRealFeatureType

--- a/users/models.py
+++ b/users/models.py
@@ -69,7 +69,7 @@ class User(AbstractUser):
             .exists()
         )
 
-    def has_responsible_entity_permission(self, responsible_entity: Optional["ResponsibleEntity"]):
+    def has_responsible_entity_permission(self, responsible_entity: Optional["ResponsibleEntity"]) -> bool:
         """
         Check if user has permissions to edit given device based on ResponsibleEntity
         """


### PR DESCRIPTION
It was possible for a user to move a device from another responsible
entity to theirs, so that user could "take over" devices.

Add several tests for device import related to
responsible entity permissions for different devices.

Refs LIIK-531