### PR TITLE
Sort enum value choices in OpenAPI schema

### DIFF
--- a/traffic_control/tests/test_schema.py
+++ b/traffic_control/tests/test_schema.py
@@ -1,0 +1,107 @@
+from enumfields import Enum
+
+from traffic_control.schema import process_enum_values
+
+
+class NumericEnum(Enum):
+    ONE = 1
+    TWO = 2
+    THREE = 3
+
+
+class StringEnum(Enum):
+    FIRST = "A"
+    SECOND = "B"
+    THIRD = "C"
+
+
+def test__process_enum_values__enum_choices_are_correct_type_and_sorted():
+    schema_input = {
+        "paths": {
+            "/path/": {
+                "get": {
+                    "parameters": [
+                        {
+                            "in": "query",
+                            "name": "numeric",
+                            "schema": {
+                                "enum": [
+                                    NumericEnum.THREE,
+                                    NumericEnum.ONE,
+                                    NumericEnum.TWO,
+                                ],
+                            },
+                        },
+                        {
+                            "in": "query",
+                            "name": "size",
+                            "schema": {
+                                "enum": [
+                                    StringEnum.SECOND,
+                                    StringEnum.THIRD,
+                                    StringEnum.FIRST,
+                                ],
+                            },
+                        },
+                        {
+                            "in": "query",
+                            "name": "other",
+                            "schema": {
+                                "enum": [
+                                    "Y",
+                                    "X",
+                                    "Z",
+                                ],
+                            },
+                        },
+                    ],
+                }
+            }
+        },
+    }
+
+    schema_expected = {
+        "paths": {
+            "/path/": {
+                "get": {
+                    "parameters": [
+                        {
+                            "in": "query",
+                            "name": "numeric",
+                            "schema": {
+                                "enum": [
+                                    1,
+                                    2,
+                                    3,
+                                ],
+                            },
+                        },
+                        {
+                            "in": "query",
+                            "name": "size",
+                            "schema": {
+                                "enum": [
+                                    "A",
+                                    "B",
+                                    "C",
+                                ],
+                            },
+                        },
+                        {
+                            "in": "query",
+                            "name": "other",
+                            "schema": {
+                                "enum": [
+                                    "Y",
+                                    "X",
+                                    "Z",
+                                ],
+                            },
+                        },
+                    ],
+                }
+            }
+        },
+    }
+
+    assert process_enum_values(None, None, None, schema_input) == schema_expected


### PR DESCRIPTION
Enums in `openapi.yaml` were not sorted as expected before. This change sorts them in the order that they appear in their enum class definition.