### PR TITLE
Configurable health check log suppression

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -48,6 +48,16 @@ elif [[ "$DEV_SERVER" = "1" ]]; then
     echo "Starting dev-server..."
     python ./manage.py runserver 0.0.0.0:8000
 else
-    echo "Starting uwsgi-server..."
-    uwsgi --ini uwsgi_docker.ini
+    UWSGI_ARGS="--ini uwsgi/docker.ini"
+
+    if [[ "$UWSGI_LOG_HEALTHZ" = "1" ]]
+    then
+        echo "Logging health and readiness check requests."
+    else
+        echo "Suppressing health and readiness checks requests."
+        UWSGI_ARGS="$UWSGI_ARGS --ini uwsgi/donotlog-health.ini"
+    fi
+
+    echo "Starting uwsgi-server at $(date)"
+    uwsgi $UWSGI_ARGS
 fi

--- a/uwsgi/docker.ini
+++ b/uwsgi/docker.ini
@@ -13,7 +13,3 @@ threads = 2
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true
-
-; Don't log readiness and health check routes to reduce noise
-route = ^/healthz$ donotlog:
-route = ^/readiness$ donotlog:

--- a/uwsgi/donotlog-health.ini
+++ b/uwsgi/donotlog-health.ini
@@ -1,0 +1,4 @@
+[uwsgi]
+; Don't log readiness and health check routes to reduce noise
+route = ^/healthz$ donotlog:
+route = ^/readiness$ donotlog:


### PR DESCRIPTION
By default we suppress the probe requests logging. Set env variable `UWSGI_LOG_HEALTHZ=1` to ignore suppression.