### PR TITLE
Add `compilemessages.sh`

### DIFF
--- a/compilemessages.sh
+++ b/compilemessages.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+python manage.py compilemessages -i "venv/*" -i "map-view/*" -l fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,7 +27,7 @@ fi
 
 # Translate messages
 echo "Updating translations..."
-./manage.py compilemessages -l fi
+./compilemessages.sh
 
 echo "Checking for odd ENTRYPOINT line in arguments"
 echo "Arguments are:"


### PR DESCRIPTION
Put translations compilation to separate shell script file to ease development. Use the same script in Docker container entrypoint too.