### PR TITLE
Ensure device geometries to be polygons when deriving Plan location

### DIFF
--- a/traffic_control/models/plan.py
+++ b/traffic_control/models/plan.py
@@ -106,7 +106,7 @@ class Plan(SourceControlModel, SoftDeleteModel, UserControlModel):
             self.location = None
         else:
             location_polygons = MultiPolygon(
-                [p.buffer(buffer) for p in self._get_related_locations()],
+                [p.buffer(buffer).convex_hull for p in locations],
                 srid=settings.SRID,
             )
             area = location_polygons.convex_hull

--- a/traffic_control/tests/models/test_plan.py
+++ b/traffic_control/tests/models/test_plan.py
@@ -76,7 +76,16 @@ def test__plan__derive_location_from_related_plans():
     bp_1 = get_barrier_plan(location=Point(10.0, 10.0, 0.0, srid=settings.SRID), plan=plan)
     bp_2 = get_barrier_plan(location=Point(5.0, 5.0, 0.0, srid=settings.SRID), plan=plan)
     mp_1 = get_mount_plan(location=Point(20.0, 5.0, 0.0, srid=settings.SRID), plan=plan)
-    mp_2 = get_mount_plan(location=Point(100.0, 10.0, 0.0, srid=settings.SRID), plan=plan)
+    mp_2 = get_mount_plan(
+        location=MultiPolygon(
+            [
+                Polygon([(x, y, 0) for x, y in Point(100.0, 0.0).buffer(1).coords[0]]),
+                Polygon([(x, y, 0) for x, y in Point(100.0, 15.0).buffer(1).coords[0]]),
+            ],
+            srid=settings.SRID,
+        ),
+        plan=plan,
+    )
     rmp_1 = get_road_marking_plan(location=Point(0.0, 50.0, 0.0, srid=settings.SRID), plan=plan)
     rmp_2 = get_road_marking_plan(location=Point(100.0, 100.0, 0.0, srid=settings.SRID), plan=plan)
     sp_1 = get_signpost_plan(location=Point(10.0, 100.0, 0.0, srid=settings.SRID), plan=plan)


### PR DESCRIPTION
`location_polygons` (`MultiPolygon`) cannot be created if any related device location's buffered geometry is a multipolygon. Taking `.convex_hull` ensures that the geometry is a polygon.

Refs: LIIK-568