### PR TITLE
Add source name and source ID to missing admin views

### DIFF
--- a/traffic_control/admin/barrier.py
+++ b/traffic_control/admin/barrier.py
@@ -84,6 +84,8 @@ class BarrierPlanAdmin(
                     "connection_type",
                     "count",
                     "txt",
+                    "source_id",
+                    "source_name",
                 )
             },
         ),
@@ -186,6 +188,8 @@ class BarrierRealAdmin(
                     "connection_type",
                     "count",
                     "txt",
+                    "source_id",
+                    "source_name",
                 )
             },
         ),

--- a/traffic_control/admin/mount.py
+++ b/traffic_control/admin/mount.py
@@ -73,6 +73,8 @@ class MountPlanAdmin(
                     "responsible_entity",
                     "electric_accountable",
                     "txt",
+                    "source_id",
+                    "source_name",
                 )
             },
         ),
@@ -175,6 +177,8 @@ class MountRealAdmin(
                     "electric_accountable",
                     "inspected_at",
                     "txt",
+                    "source_id",
+                    "source_name",
                 )
             },
         ),

--- a/traffic_control/tests/test_source_name_source_id_api.py
+++ b/traffic_control/tests/test_source_name_source_id_api.py
@@ -113,7 +113,7 @@ def get_data_create_furniture_signpost():
     ),
 )
 @pytest.mark.django_db
-def test__traffic_sign__source_name_source_id(client, model, url_name, data_factory):
+def test__traffic_sign__source_name_source_id(model, url_name, data_factory):
     """Test that source_name and source_id are unique in non-deleted objects."""
 
     client = get_api_client(user=get_user(admin=True))


### PR DESCRIPTION
Barriers and mounts were missing source name and id from their admin view.