### PR TITLE
fix: Allow only JSONRenderer as DRF default renderer

### DIFF
--- a/cityinfra/settings.py
+++ b/cityinfra/settings.py
@@ -285,6 +285,9 @@ REST_FRAMEWORK = {
     "OIDC_LEEWAY": env("TOKEN_AUTH_MAX_TOKEN_AGE"),
     "GROUP_CLAIM_NAME": "groups",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+    ],
 }
 
 SPECTACULAR_SETTINGS = {
@@ -333,7 +336,6 @@ BASEMAP_SOURCE_URL = env.str("BASEMAP_SOURCE_URL")
 IMPORT_EXPORT_USE_TRANSACTIONS = True
 # Require add permission even to export template
 IMPORT_EXPORT_EXPORT_PERMISSION_CODE = "add"
-
 
 # WFS
 GISSERVER_USE_DB_RENDERING = False


### PR DESCRIPTION
* BrowsableAPIRenderer causes over 1000 db hits, because it populates selection lists for many objects
* As it is not needed better just to remove it totally
*  instead of making alot of selected related statements

Refs: LIIK-602