### PR TITLE
fix: Many fixes related to location handling in admin forms

### DIFF
--- a/traffic_control/geometry_utils.py
+++ b/traffic_control/geometry_utils.py
@@ -78,6 +78,7 @@ def get_3d_linestring(linestring: LineString, z_coord: float) -> LineString:
 
 
 def get_z_for_geometry(geometry):
+    """For geometries that have multiple subgeometries z coordinate from the first one is returned."""
     if isinstance(geometry, Point):
         return get_z_for_point(geometry)
     elif isinstance(geometry, LinearRing):
@@ -88,6 +89,9 @@ def get_z_for_geometry(geometry):
         return get_z_for_multipolygon(geometry)
     elif isinstance(geometry, LineString):
         return get_z_for_linestring(geometry)
+    elif isinstance(geometry, GeometryCollection):
+        return get_z_for_geometry(geometry[0])
+    raise NotImplementedError(f"Could not get z for geometry {type(geometry)}")
 
 
 def get_z_for_point(point: Point) -> float:

--- a/traffic_control/tests/test_additional_sign_admin.py
+++ b/traffic_control/tests/test_additional_sign_admin.py
@@ -308,3 +308,41 @@ def test_additional_sign_illegal_location(client: Client, model, factory, url_na
     assert model.objects.count() == 0
     assert "location" in response.context["adminform"].form.errors
     assert response.context["adminform"].form.errors["location"] == [f"Invalid location: {illegal_test_point.ewkt}"]
+
+
+@pytest.mark.parametrize(
+    "model,url_name,parent_factory",
+    (
+        (AdditionalSignPlan, "additionalsignplan", None),
+        (AdditionalSignReal, "additionalsignreal", TrafficSignRealFactory),
+    ),
+)
+@pytest.mark.django_db
+def test__additional_sign_create_with_location_ewkt(client: Client, model, url_name, parent_factory):
+    client.force_login(get_user(admin=True))
+    device_type = get_traffic_control_device_type(content_schema=simple_schema)
+    data = {
+        "missing_content": True,
+        "content_s": "null",
+        "location_ewkt": test_point.ewkt,
+        "owner": str(get_owner().pk),
+        "device_type": str(device_type.pk),
+        "z_coord": 0,
+        "direction": 0,
+        "order": 0,
+        "lifecycle": Lifecycle.ACTIVE.value,
+        "operations-TOTAL_FORMS": 0,
+        "operations-INITIAL_FORMS": 0,
+        "replacement_to_old-TOTAL_FORMS": 0,
+        "replacement_to_old-INITIAL_FORMS": 0,
+        "replacement_to_new-TOTAL_FORMS": 0,
+        "replacement_to_new-INITIAL_FORMS": 0,
+        "files-TOTAL_FORMS": 0,
+        "files-INITIAL_FORMS": 0,
+    }
+    if parent_factory:
+        data.update({"parent": parent_factory().id})
+    response = client.post(reverse(f"admin:traffic_control_{url_name}_add"), data=data)
+    assert response.status_code == HTTPStatus.FOUND
+    assert model.objects.count() == 1
+    assert model.objects.get().location == test_point.ewkt


### PR DESCRIPTION
* initial z coordinate value get for GeometryCollections.
* Fixed changing other fields than location fixed, this was due to differently rounded values from mapwidget in each run.
* Creating objects with only location_ewkt field is now working
* No more additional logentries, this also happened due to mapwidget coordinate rounding
* Fixed 500 Error when creating objects where location field is not mandatory

Refs: LIIK-705