### PR TITLE
fix: Add missing internationalization support for mount centroid titles

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-15 20:24+0200\n"
+"POT-Creation-Date: 2024-12-20 15:30+0200\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2274,6 +2274,12 @@ msgstr "Tiedostoa ei löytynyt."
 #, python-format
 msgid "Error: Could not find %(model_name)s with id %(id)s."
 msgstr "Virhe: %(model_name)s tunnisteella %(id)s ei löytynyt."
+
+msgid "Mount Real Centroid"
+msgstr "Kiinnityskohta_keskipiste (toteuma)"
+
+msgid "Mount Plan Centroid"
+msgstr "Kiinnityskohta_keskipiste (suunnitelma)"
 
 msgid "Additional user information"
 msgstr "Lisätiedot käyttäjälle"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-15 20:24+0200\n"
+"POT-Creation-Date: 2024-12-20 15:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2281,6 +2281,12 @@ msgstr "Fil hittades inte."
 #, python-format
 msgid "Error: Could not find %(model_name)s with id %(id)s."
 msgstr "Fel: Kunde inte hittas med koden %(model_name)s %(id)s."
+
+msgid "Mount Real Centroid"
+msgstr "Montering_medelpunkt (implementering)"
+
+msgid "Mount Plan Centroid"
+msgstr "Montering_medelpunkt (plan)"
 
 msgid "Additional user information"
 msgstr ""

--- a/traffic_control/views/wfs/mount.py
+++ b/traffic_control/views/wfs/mount.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from django.db.models import Q
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from gisserver.features import FeatureField, FeatureType, field
 
 from traffic_control.enums import Lifecycle
@@ -74,7 +75,7 @@ MountRealFeatureType = FeatureType(
 
 
 MountRealCentroidFeatureType = FeatureType(
-    title="Mount Real Centroid",
+    title=_("Mount Real Centroid"),
     name="mountrealcentroid",
     crs=DEFAULT_CRS,
     other_crs=OTHER_CRS,
@@ -115,7 +116,7 @@ MountPlanFeatureType = FeatureType(
 
 
 MountPlanCentroidFeatureType = FeatureType(
-    title="Mount Plan Centroid",
+    title=_("Mount Plan Centroid"),
     name="mountplancentroid",
     crs=DEFAULT_CRS,
     other_crs=OTHER_CRS,


### PR DESCRIPTION
* Finnish and swedish translation also added

Refs: LIIK-710