### PR TITLE
fix: Derive location confirmation not asked when it should be

### DIFF
--- a/traffic_control/admin/plan.py
+++ b/traffic_control/admin/plan.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 from django.contrib.gis import admin
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -77,10 +79,10 @@ class PlanAdmin(
         """This is an overridden function from CityInfraAdminConfirmMixin(AdminConfirmMixin)
         for getting confirmation fields dynamically.
         """
-        base_fields = super().get_confirmation_fields(request, obj)
+        base_fields = copy(super().get_confirmation_fields(request, obj))
         if request.POST.get("derive_location") != "on":
-            if "location" in base_fields:
-                base_fields.remove("location")
+            # location should always be there
+            base_fields.remove("location")
         return base_fields
 
     def get_urls(self):


### PR DESCRIPTION
* First fix just fixed the symptom not the root cause
* Root cause was that AdminConfirmMixin.get_confirmation_fields does not return a copy of confirmation fields
* and when PlanAdmin removes "location" fields from confirmation fields once, it is never there again without taking a copy

Refs: LIIK-750