### PR TITLE
Plan real distance fix

### DIFF
--- a/map-view/src/App.tsx
+++ b/map-view/src/App.tsx
@@ -74,7 +74,7 @@ class App extends React.Component<AppProps, AppState> {
               onSelectFeature={(feature: Feature) => Map.showPlanOfRealDevice(feature, mapConfig)}
               onClose={() => {
                 this.setState({ features: [] });
-                Map.clearPlanRealDiffVectorLayer();
+                Map.clearPlanOfRealVectorLayer();
               }}
             />
           )}

--- a/map-view/src/common/Map.ts
+++ b/map-view/src/common/Map.ts
@@ -284,15 +284,18 @@ class Map {
         .flat(1);
 
       if (realFeatures.length && planFeatures.length) {
-        realFeatures.forEach((realFeature) => {
+        const byPlanId = Object.fromEntries(planFeatures.map((pf) => {
+          return [pf.get("id"), pf];
+        }));
+        for (const realFeature of realFeatures) {
           const device_plan_id = realFeature.get("device_plan_id");
           if (device_plan_id) {
-            const planFeature = planFeatures.filter((planFeature) => planFeature.get("id") === device_plan_id);
-            if (planFeature.length) {
-              this.drawLineBetweenFeatures(realFeature, planFeature[0]);
+            const planFeature = byPlanId[device_plan_id];
+            if (planFeature) {
+              this.drawLineBetweenFeatures(realFeature, planFeature);
             }
           }
-        });
+        }
       }
     }
   }


### PR DESCRIPTION
Moved selected real's plan (red dot) to own layer.
Includes a performance fix for drawing the diff lines, from 32s to 300ms with production data for trafficsign layers.
