### PR TITLE
Fix/LIIK-928 improper html collations pt2

### DIFF
--- a/traffic_control/admin/ticket_machine_migration.py
+++ b/traffic_control/admin/ticket_machine_migration.py
@@ -1,6 +1,7 @@
 """Django admin configuration for ticket machine migration tracking models."""
 from django.contrib import admin
 from django.db import models
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -379,27 +380,17 @@ class TicketMachineMigrationRunAdmin(admin.ModelAdmin):
     @admin.display(description=_("Lost Field Values"))
     def lost_field_values_display(self, obj: TicketMachineMigrationRun) -> str:
         """Display lost field values in a formatted way."""
-        # Define all possible lost fields
         all_lost_fields = ["value", "txt", "double_sided", "peak_fastened", "affect_area"]
+        lost_data = obj.lost_field_values or {}
 
-        if not obj.lost_field_values:
-            # No data tracked yet, show all fields as empty
-            output = []
-            for field in all_lost_fields:
-                output.append(f'<strong>{field}</strong>: <span style="color: #28a745;">No data lost</span>')
-            return mark_safe("<br/>".join(output))
-
-        output = []
+        field_data = []
         for field in all_lost_fields:
-            values = obj.lost_field_values.get(field, [])
-            if values:
-                value_count = len(values)
-                all_values = ", ".join(str(v) for v in values)
-                output.append(f"<strong>{field}</strong> ({value_count} unique): {all_values}")
-            else:
-                output.append(f'<strong>{field}</strong>: <span style="color: #28a745;">No data lost</span>')
+            values = lost_data.get(field, [])
+            field_data.append({"name": field, "values": values})
 
-        return mark_safe("<br/>".join(output))
+        context = {"fields": field_data}
+
+        return render_to_string("admin/traffic_control/ticketmachinemigrationrun/lost_field_values.html", context)
 
 
 @admin.register(TicketMachineMigrationPlanRecord)

--- a/traffic_control/forms.py
+++ b/traffic_control/forms.py
@@ -7,7 +7,6 @@ from django.forms.models import BaseInlineFormSet, ModelChoiceIteratorValue
 from django.forms.widgets import Select
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from enumfields.forms import EnumChoiceField
 
@@ -113,7 +112,7 @@ class AdminStructuredContentWidget(forms.Widget):
             "device_type_name": device_type_name,
             "devices_api_url": reverse("v1:trafficcontroldevicetype-detail", kwargs={"pk": "__id__"}),
         }
-        return mark_safe(render_to_string(self.template_name, context))
+        return render_to_string(self.template_name, context)
 
     class Media:
         css = {"all": ("traffic_control/css/structured_content_widget.css",)}

--- a/traffic_control/mixins/admin.py
+++ b/traffic_control/mixins/admin.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.contrib.gis.forms import OSMWidget
-from django.utils.html import escape, format_html
-from django.utils.safestring import mark_safe
+from django.template.loader import render_to_string
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from admin_helper.decorators import requires_fields
@@ -132,22 +132,8 @@ class FormattedContentsAdminMixin:
         if not obj or not hasattr(obj, "get_content_s_rows"):
             return "-"
 
-        content_s_rows = obj.get_content_s_rows()
-
-        if not content_s_rows:
-            return "-"
-
-        # Build HTML parts with proper escaping
-        html_parts = ["<dl>"]
-        for title, display_value in content_s_rows:
-            # Escape and handle None values
-            safe_value = escape(display_value) if display_value is not None else "-"
-            safe_title = escape(title)
-            html_parts.append(f"<dt>{safe_title}</dt><dd>{safe_value}</dd>")
-        html_parts.append("</dl>")
-
-        # Mark as safe since we've manually escaped the content
-        return mark_safe("".join(html_parts))
+        context = {"content_s_rows": obj.get_content_s_rows()}
+        return render_to_string("embed/_content_s_rows.html", context)
 
 
 class UserStampedAdminMixin:

--- a/traffic_control/templates/admin/traffic_control/ticketmachinemigrationrun/lost_field_values.html
+++ b/traffic_control/templates/admin/traffic_control/ticketmachinemigrationrun/lost_field_values.html
@@ -1,0 +1,13 @@
+<div class="lost-field-values">
+    {% for field in fields %}
+        <div style="margin-bottom: 4px">
+            <strong>{{ field.name }}</strong>
+
+            {% if field.values %}
+                ({{ field.values|length }} unique): {{ field.values|join:", " }}
+            {% else %}
+                : <span style="color: #28a745">No data lost</span>
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>

--- a/traffic_control/tests/test_formatted_contents_admin_mixin.py
+++ b/traffic_control/tests/test_formatted_contents_admin_mixin.py
@@ -11,6 +11,10 @@ from traffic_control.tests.factories import (
 )
 
 
+def strip_indentation(text):
+    return "".join([line.strip() for line in text.split("\n")])
+
+
 class MockAdminWithMixin(FormattedContentsAdminMixin):
     """Mock admin class for testing the mixin."""
 
@@ -60,7 +64,7 @@ def test__content__returns_dash_when_no_get_content_s_rows_method(mock_admin: Mo
 @pytest.mark.parametrize("as_factory", (AdditionalSignPlanFactory, AdditionalSignRealFactory))
 @pytest.mark.django_db
 def test__content__returns_dash_when_content_s_rows_empty(mock_admin: MockAdminWithMixin, as_factory) -> None:
-    """Test that content returns '-' when content_s_rows is empty.
+    """Test that content returns '<dl >-</dl>' when content_s_rows is empty.
 
     Args:
         mock_admin (MockAdminWithMixin): Mock admin instance.
@@ -73,8 +77,8 @@ def test__content__returns_dash_when_content_s_rows_empty(mock_admin: MockAdminW
     )
     additional_sign = as_factory(device_type=device_type, content_s=None)
 
-    result = mock_admin.content(additional_sign)
-    assert result == "-"
+    result = strip_indentation(mock_admin.content(additional_sign))
+    assert result == "<dl >-</dl>"
 
 
 @pytest.mark.parametrize("as_factory", (AdditionalSignPlanFactory, AdditionalSignRealFactory))
@@ -105,9 +109,9 @@ def test__content__returns_html_with_single_row(mock_admin: MockAdminWithMixin, 
     additional_sign = as_factory(device_type=device_type, content_s={"limit": 2})
 
     activate("en")
-    result = mock_admin.content(additional_sign)
+    result = strip_indentation(mock_admin.content(additional_sign))
 
-    assert result.startswith("<dl>")
+    assert result.startswith("<dl >")
     assert result.endswith("</dl>")
     assert "<dt>Time limit</dt>" in result
     assert "<dd>2</dd>" in result
@@ -155,9 +159,9 @@ def test__content__returns_html_with_multiple_rows(mock_admin: MockAdminWithMixi
     )
 
     activate("en")
-    result = mock_admin.content(additional_sign)
+    result = strip_indentation(mock_admin.content(additional_sign))
 
-    assert result.startswith("<dl>")
+    assert result.startswith("<dl >")
     assert result.endswith("</dl>")
     # Check that all content is present (unit is combined with limit)
     assert "<dt>Time limit</dt>" in result
@@ -227,7 +231,7 @@ def test__content__handles_none_values(mock_admin: MockAdminWithMixin, as_factor
             """
             return [("Field", None)]
 
-    result = mock_admin.content(MockObj())
+    result = strip_indentation(mock_admin.content(MockObj()))
 
     assert "<dt>Field</dt>" in result
     assert "<dd>-</dd>" in result
@@ -309,7 +313,7 @@ def test__content__handles_special_characters(mock_admin: MockAdminWithMixin, as
     )
 
     activate("en")
-    result = mock_admin.content(additional_sign)
+    result = strip_indentation(mock_admin.content(additional_sign))
 
     # Ensure special characters are escaped
     assert "&amp;" in result

--- a/users/admin.py
+++ b/users/admin.py
@@ -6,11 +6,11 @@ from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin, UserAdmin as
 from django.contrib.auth.models import Group
 from django.db import models as django_models, transaction
 from django.db.models import Exists, OuterRef
+from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.formats import localize
-from django.utils.html import format_html, format_html_join
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from social_django.models import UserSocialAuth
 
@@ -386,6 +386,7 @@ class UserAdmin(BaseUserAdmin):
             # Grouping
             app_name = related_meta.app_config.verbose_name.title()
             model_name = related_meta.verbose_name.title()
+
             # soft_deleted has to be omitted from the filter query as it breaks the filter on some models
             count = field.field.model.objects.filter(**{query_param: obj.pk}).count()
 
@@ -401,45 +402,24 @@ class UserAdmin(BaseUserAdmin):
 
         # Table rows assembly
         row_data = []
-        for index, (app_name, mod_name) in enumerate(sorted_keys):
+        for app_name, mod_name in sorted_keys:
             columns = sorted(groups[(app_name, mod_name)], key=lambda x: x["text"].lower())
-            td_cells = (
-                format_html('<td><a href="{url}">{text}</a></td>', **e)
-                if e.get("url")
-                else format_html("<td>{text}</td>", **e)
-                for e in columns
-            )
-            td_cells_joined = mark_safe("".join(td_cells))  # risky bits already escaped by format_html
-            missing_cols = max_relations - len(columns)
-            padding_html = format_html('<td colspan="{colspan}"></td>', colspan=missing_cols) if missing_cols else ""
+
             row_data.append(
                 {
-                    "row_class": f"row{(index % 2) + 1}",
                     "app": app_name,
                     "model": mod_name,
-                    "td_cells": td_cells_joined,
-                    "padding": padding_html,
+                    "columns": columns,
+                    "missing_cols": max_relations - len(columns),
                 }
             )
 
-        # Full table Layout & Rendering
-        thead = format_html(
-            "<thead><tr>"
-            "<th>{app_label}</th>"
-            "<th>{model_label}</th>"
-            '<th colspan="{colspan}">{view_related_label}</th>'
-            "</tr></thead>",
-            app_label=_("App"),
-            model_label=_("Model"),
-            colspan=max_relations,
-            view_related_label=_("View related"),
-        )
-        trows = format_html_join(
-            "", '<tr class="{row_class}"><td>{app}</td><td>{model}</td>{td_cells}{padding}</tr>', row_data
-        )
-        return format_html(
-            '<div class="results"><table>{thead}<tbody>{trows}</tbody></table></div>', thead=thead, trows=trows
-        )
+        context = {
+            "max_relations": max_relations,
+            "rows": row_data,
+        }
+
+        return render_to_string("admin/users/user/relations_table.html", context)
 
     @admin.action(permissions=["change"], description=_("Reactivate selected users"))
     def reactivate_selected_users(self, request, queryset) -> None:

--- a/users/admin.py
+++ b/users/admin.py
@@ -11,6 +11,7 @@ from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.formats import localize
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from social_django.models import UserSocialAuth
 
@@ -538,15 +539,15 @@ class UserDeactivationStatusAdmin(admin.ModelAdmin):
             str: HTML formatted status string.
         """
         if obj.deactivated_at:
-            return format_html('<span style="color: red; font-weight: bold;">DEACTIVATED</span>')
+            return mark_safe('<span style="color: red; font-weight: bold;">DEACTIVATED</span>')
         elif obj.one_day_email_sent_at:
-            return format_html('<span style="color: orange; font-weight: bold;">1-DAY WARNING SENT</span>')
+            return mark_safe('<span style="color: orange; font-weight: bold;">1-DAY WARNING SENT</span>')
         elif obj.one_week_email_sent_at:
-            return format_html('<span style="color: #ff9800; font-weight: bold;">7-DAY WARNING SENT</span>')
+            return mark_safe('<span style="color: #ff9800; font-weight: bold;">7-DAY WARNING SENT</span>')
         elif obj.one_month_email_sent_at:
-            return format_html('<span style="color: #ffc107;">30-DAY WARNING SENT</span>')
+            return mark_safe('<span style="color: #ffc107;">30-DAY WARNING SENT</span>')
         else:
-            return format_html('<span style="color: gray;">PENDING</span>')
+            return mark_safe('<span style="color: gray;">PENDING</span>')
 
     def has_add_permission(self, request):
         """

--- a/users/templates/admin/users/user/relations_table.html
+++ b/users/templates/admin/users/user/relations_table.html
@@ -1,0 +1,33 @@
+{% load i18n %}
+
+<div class="results">
+    <table id="result_list">
+        <thead>
+            <tr>
+                <th>{% translate "App" %}</th>
+                <th>{% translate "Model" %}</th>
+                <th colspan="{{ max_relations }}">{% translate "View related" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+                <tr class="{% cycle 'row1' 'row2' %}">
+                    <td>{{ row.app }}</td>
+                    <td>{{ row.model }}</td>
+
+                    {% for col in row.columns %}
+                        <td>
+                            {% if col.url %}
+                                <a href="{{ col.url }}">{{ col.text }}</a>
+                            {% else %}
+                                {{ col.text }}
+                            {% endif %}
+                        </td>
+                    {% endfor %}
+
+                    {% if row.missing_cols %}<td colspan="{{ row.missing_cols }}"></td>{% endif %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
- Move complicated and risky HTML assembly functions to django templates
- Ensure no `format_html` calls without values for interpolation
- Ensure  `mark_safe` calls are only done with hardcoded strings