### PR TITLE
Allow editing plan replacements in admin via service layer

### DIFF
--- a/cityinfra/templates/admin/base.html
+++ b/cityinfra/templates/admin/base.html
@@ -77,6 +77,10 @@
           method="post"
           action="{% url 'set_language' %}">
         {% csrf_token %}
+        <input type="hidden"
+               name="next"
+               id="language-next"
+               value="{{ request.get_full_path }}">
         <label class="language-select-label"
                for="language-select">{% trans "Language" %}:</label>
         <select class="language-select"
@@ -97,7 +101,19 @@
     <script>
     function changeLanguage(languageCode) {
       const form = document.getElementById('languageSelectForm');
+      const supportedLanguageCodes = [{% for lang_code, lang_name in LANGUAGES %}"{{ lang_code }}"{% if not forloop.last %}, {% endif %}{% endfor %}];
+      const currentUrl = new URL(window.location.href);
+      const pathSegments = currentUrl.pathname.split('/');
+
+      if (pathSegments.length > 1 && supportedLanguageCodes.includes(pathSegments[1])) {
+        pathSegments[1] = languageCode;
+      } else {
+        pathSegments.splice(1, 0, languageCode);
+      }
+
+      const targetPath = pathSegments.join('/') || '/';
       form.elements.language.value = languageCode;
+      form.elements.next.value = `${targetPath}${currentUrl.search}${currentUrl.hash}`;
       form.submit();
     }
     </script>

--- a/traffic_control/admin/additional_sign.py
+++ b/traffic_control/admin/additional_sign.py
@@ -24,6 +24,7 @@ from traffic_control.admin.utils import (
     AdminFieldInitialValuesMixin,
     DeviceComparisonAdminMixin,
     MultiResourceExportActionAdminMixin,
+    ReplaceablePlanServiceAdminMixin,
 )
 from traffic_control.enums import Condition, InstallationStatus, LaneNumber, LaneType, Reflection, Size, Surface
 from traffic_control.forms import (
@@ -62,6 +63,7 @@ from traffic_control.resources.additional_sign import (
     AdditionalSignRealResource,
 )
 from traffic_control.resources.common import CustomImportExportActionModelAdmin
+from traffic_control.services.additional_sign import additional_sign_plan_update
 
 shared_initial_values = {
     "size": Size.MEDIUM,
@@ -183,6 +185,7 @@ class AdditionalSignPlanAdmin(
     Geometry3DFieldAdminMixin,
     MultiResourceExportActionAdminMixin,
     AdminFieldInitialValuesMixin,
+    ReplaceablePlanServiceAdminMixin,
     UpdatePlanLocationAdminMixin,
     admin.GISModelAdmin,
     AuditLogHistoryAdmin,
@@ -192,6 +195,7 @@ class AdditionalSignPlanAdmin(
 ):
     resource_class = AdditionalSignPlanResource
     extra_export_resource_classes = [AdditionalSignPlanToRealTemplateResource]
+    plan_update_service = additional_sign_plan_update
     form = AdditionalSignPlanModelForm
     fieldsets = (
         (

--- a/traffic_control/admin/barrier.py
+++ b/traffic_control/admin/barrier.py
@@ -22,6 +22,7 @@ from traffic_control.admin.utils import (
     AdminFieldInitialValuesMixin,
     DeviceComparisonAdminMixin,
     MultiResourceExportActionAdminMixin,
+    ReplaceablePlanServiceAdminMixin,
 )
 from traffic_control.enums import Condition, InstallationStatus, LaneNumber, LaneType
 from traffic_control.forms import (
@@ -48,6 +49,7 @@ from traffic_control.resources.barrier import (
     BarrierRealResource,
 )
 from traffic_control.resources.common import CustomImportExportActionModelAdmin
+from traffic_control.services.barrier import barrier_plan_update
 
 __all__ = (
     "BarrierPlanAdmin",
@@ -126,6 +128,7 @@ class BarrierPlanAdmin(
     Geometry3DFieldAdminMixin,
     MultiResourceExportActionAdminMixin,
     AdminFieldInitialValuesMixin,
+    ReplaceablePlanServiceAdminMixin,
     UpdatePlanLocationAdminMixin,
     admin.GISModelAdmin,
     AuditLogHistoryAdmin,
@@ -134,6 +137,7 @@ class BarrierPlanAdmin(
 ):
     resource_class = BarrierPlanResource
     extra_export_resource_classes = [BarrierPlanToRealTemplateResource]
+    plan_update_service = barrier_plan_update
     form = BarrierPlanModelForm
     fieldsets = (
         (

--- a/traffic_control/admin/common.py
+++ b/traffic_control/admin/common.py
@@ -282,7 +282,7 @@ class ReplacesInline(PermissionInlineMixin, admin.StackedInline):
     fk_name = "new"
     verbose_name = _("Replaces")
     raw_id_fields = ("old",)
-    # TODO: Modifying replacements can be allowed when Admin UI uses service layer functions
+    # Replacement editing is handled in plan admin forms through service layer functions.
     readonly_fields = ("old",)
 
 

--- a/traffic_control/admin/mount.py
+++ b/traffic_control/admin/mount.py
@@ -23,6 +23,7 @@ from traffic_control.admin.utils import (
     AdminFieldInitialValuesMixin,
     DeviceComparisonAdminMixin,
     MultiResourceExportActionAdminMixin,
+    ReplaceablePlanServiceAdminMixin,
 )
 from traffic_control.enums import Condition, InstallationStatus
 from traffic_control.forms import (
@@ -51,6 +52,7 @@ from traffic_control.models import (
 )
 from traffic_control.resources.common import CustomImportExportActionModelAdmin
 from traffic_control.resources.mount import MountPlanResource, MountPlanToRealTemplateResource, MountRealResource
+from traffic_control.services.mount import mount_plan_update
 
 __all__ = (
     "MountPlanAdmin",
@@ -123,6 +125,7 @@ class MountPlanAdmin(
     Geometry3DFieldAdminMixin,
     MultiResourceExportActionAdminMixin,
     AdminFieldInitialValuesMixin,
+    ReplaceablePlanServiceAdminMixin,
     UpdatePlanLocationAdminMixin,
     admin.GISModelAdmin,
     AuditLogHistoryAdmin,
@@ -130,6 +133,7 @@ class MountPlanAdmin(
 ):
     resource_class = MountPlanResource
     extra_export_resource_classes = [MountPlanToRealTemplateResource]
+    plan_update_service = mount_plan_update
     form = MountPlanModelForm
     fieldsets = (
         (

--- a/traffic_control/admin/road_marking.py
+++ b/traffic_control/admin/road_marking.py
@@ -22,6 +22,7 @@ from traffic_control.admin.utils import (
     AdminFieldInitialValuesMixin,
     DeviceComparisonAdminMixin,
     MultiResourceExportActionAdminMixin,
+    ReplaceablePlanServiceAdminMixin,
 )
 from traffic_control.enums import Condition, InstallationStatus, LaneNumber, LaneType
 from traffic_control.forms import (
@@ -48,6 +49,7 @@ from traffic_control.resources.road_marking import (
     RoadMarkingPlanToRealTemplateResource,
     RoadMarkingRealResource,
 )
+from traffic_control.services.road_marking import road_marking_plan_update
 
 __all__ = (
     "RoadMarkingPlanAdmin",
@@ -134,6 +136,7 @@ class RoadMarkingPlanAdmin(
     Geometry3DFieldAdminMixin,
     MultiResourceExportActionAdminMixin,
     AdminFieldInitialValuesMixin,
+    ReplaceablePlanServiceAdminMixin,
     UpdatePlanLocationAdminMixin,
     admin.GISModelAdmin,
     AuditLogHistoryAdmin,
@@ -142,6 +145,7 @@ class RoadMarkingPlanAdmin(
 ):
     resource_class = RoadMarkingPlanResource
     extra_export_resource_classes = [RoadMarkingPlanToRealTemplateResource]
+    plan_update_service = road_marking_plan_update
     form = RoadMarkingPlanModelForm
     SHOW_Z_COORD = False
     fieldsets = (

--- a/traffic_control/admin/signpost.py
+++ b/traffic_control/admin/signpost.py
@@ -22,6 +22,7 @@ from traffic_control.admin.utils import (
     AdminFieldInitialValuesMixin,
     DeviceComparisonAdminMixin,
     MultiResourceExportActionAdminMixin,
+    ReplaceablePlanServiceAdminMixin,
 )
 from traffic_control.enums import Condition, InstallationStatus, LaneNumber, LaneType, Reflection, Size
 from traffic_control.forms import (
@@ -48,6 +49,7 @@ from traffic_control.resources.signpost import (
     SignpostPlanToRealTemplateResource,
     SignpostRealResource,
 )
+from traffic_control.services.signpost import signpost_plan_update
 
 __all__ = (
     "SignpostPlanAdmin",
@@ -125,6 +127,7 @@ class SignpostPlanAdmin(
     Geometry3DFieldAdminMixin,
     MultiResourceExportActionAdminMixin,
     AdminFieldInitialValuesMixin,
+    ReplaceablePlanServiceAdminMixin,
     UpdatePlanLocationAdminMixin,
     admin.GISModelAdmin,
     AuditLogHistoryAdmin,
@@ -133,6 +136,7 @@ class SignpostPlanAdmin(
 ):
     resource_class = SignpostPlanResource
     extra_export_resource_classes = [SignpostPlanToRealTemplateResource]
+    plan_update_service = signpost_plan_update
     form = SignpostPlanModelForm
     fieldsets = (
         (

--- a/traffic_control/admin/traffic_light.py
+++ b/traffic_control/admin/traffic_light.py
@@ -22,6 +22,7 @@ from traffic_control.admin.utils import (
     AdminFieldInitialValuesMixin,
     DeviceComparisonAdminMixin,
     MultiResourceExportActionAdminMixin,
+    ReplaceablePlanServiceAdminMixin,
 )
 from traffic_control.enums import Condition, InstallationStatus, LaneNumber, LaneType
 from traffic_control.forms import (
@@ -49,6 +50,7 @@ from traffic_control.resources.traffic_light import (
     TrafficLightPlanToRealTemplateResource,
     TrafficLightRealResource,
 )
+from traffic_control.services.traffic_light import traffic_light_plan_update
 
 __all__ = (
     "TrafficLightPlanAdmin",
@@ -124,6 +126,7 @@ class TrafficLightPlanAdmin(
     Geometry3DFieldAdminMixin,
     MultiResourceExportActionAdminMixin,
     AdminFieldInitialValuesMixin,
+    ReplaceablePlanServiceAdminMixin,
     UpdatePlanLocationAdminMixin,
     admin.GISModelAdmin,
     AuditLogHistoryAdmin,
@@ -132,6 +135,7 @@ class TrafficLightPlanAdmin(
 ):
     resource_class = TrafficLightPlanResource
     extra_export_resource_classes = [TrafficLightPlanToRealTemplateResource]
+    plan_update_service = traffic_light_plan_update
     form = TrafficLightPlanModelForm
     fieldsets = (
         (

--- a/traffic_control/admin/traffic_sign.py
+++ b/traffic_control/admin/traffic_sign.py
@@ -28,6 +28,7 @@ from traffic_control.admin.utils import (
     AdminFieldInitialValuesMixin,
     DeviceComparisonAdminMixin,
     MultiResourceExportActionAdminMixin,
+    ReplaceablePlanServiceAdminMixin,
 )
 from traffic_control.enums import (
     Condition,
@@ -81,6 +82,7 @@ from traffic_control.resources.traffic_sign import (
     TrafficSignPlanToRealTemplateResource,
     TrafficSignRealResource,
 )
+from traffic_control.services.traffic_sign import traffic_sign_plan_update
 
 __all__ = (
     "OrderedTrafficSignRealInline",
@@ -214,6 +216,7 @@ class TrafficSignPlanAdmin(
     Geometry3DFieldAdminMixin,
     MultiResourceExportActionAdminMixin,
     AdminFieldInitialValuesMixin,
+    ReplaceablePlanServiceAdminMixin,
     UpdatePlanLocationAdminMixin,
     admin.GISModelAdmin,
     AuditLogHistoryAdmin,
@@ -222,6 +225,7 @@ class TrafficSignPlanAdmin(
 ):
     resource_class = TrafficSignPlanResource
     extra_export_resource_classes = [TrafficSignPlanToRealTemplateResource]
+    plan_update_service = traffic_sign_plan_update
     form = TrafficSignPlanModelForm
     fieldsets = (
         (
@@ -236,6 +240,7 @@ class TrafficSignPlanAdmin(
                     "txt",
                     "source_id",
                     "source_name",
+                    "replaces",
                 )
             },
         ),

--- a/traffic_control/admin/utils.py
+++ b/traffic_control/admin/utils.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import List, Tuple, Type
 
 import tablib
@@ -194,3 +195,54 @@ class PermissionInlineMixin:
 
     def has_view_permission(self, _request, _obj):
         return self.permissions.get("view")
+
+
+class ReplaceablePlanServiceAdminMixin:
+    """
+    Updates plan replacements through the service layer instead of inline model writes.
+    """
+
+    plan_update_service = None
+
+    @staticmethod
+    def _contains_field(fields, field_name: str) -> bool:
+        for field in fields:
+            if isinstance(field, (list, tuple)):
+                if ReplaceablePlanServiceAdminMixin._contains_field(field, field_name):
+                    return True
+                continue
+
+            if field == field_name:
+                return True
+
+        return False
+
+    def get_fieldsets(self, request, obj=None, **kwargs):
+        fieldsets = deepcopy(super().get_fieldsets(request, obj=obj, **kwargs))
+        for _, options in fieldsets:
+            fields = options.get("fields", ())
+            if self._contains_field(fields, "plan") and not self._contains_field(fields, "replaces"):
+                options["fields"] = (*fields, "replaces")
+                break
+
+        return fieldsets
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        """Avoid passing custom form-only fields to modelform_factory field filtering."""
+        fields = kwargs.get("fields")
+        if fields:
+            kwargs["fields"] = tuple(field for field in fields if field != "replaces")
+
+        return super().get_form(request, obj=obj, change=change, **kwargs)
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+
+        service = type(self).plan_update_service
+        if not service:
+            return
+
+        if "replaces" not in form.cleaned_data or "replaces" not in form.changed_data:
+            return
+
+        service(instance=obj, data={"replaces": form.cleaned_data["replaces"]})

--- a/traffic_control/forms.py
+++ b/traffic_control/forms.py
@@ -32,6 +32,7 @@ from traffic_control.models import (
     TrafficSignPlan,
     TrafficSignReal,
 )
+from traffic_control.services.common import device_plan_get_current, validate_device_plan_replacement
 from traffic_control.services.virus_scan import add_virus_scan_errors_to_auditlog, get_error_details_message
 from traffic_control.utils import get_file_upload_obstacles, get_icon_upload_obstacles
 from traffic_control.validators import validate_location_ewkt, validate_structured_content
@@ -187,6 +188,46 @@ class SRIDBoundGeometryFormMixin:
         return cleaned_data
 
 
+class ReplaceablePlanModelFormMixin:
+    """
+    Adds `replaces` field to replaceable plan admin forms.
+
+    The field is validated with the same invariants as the service layer to
+    surface clear form errors before save.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if "replaces" not in self.fields:
+            self.fields["replaces"] = forms.ModelChoiceField(
+                queryset=Plan.objects.none(),
+                required=False,
+                label=_("Replaces"),
+            )
+
+        model = self._meta.model
+        instance = self.instance
+        current_replaces = instance.replaces if instance and instance.pk else None
+
+        queryset = device_plan_get_current(model)
+        if instance and instance.pk:
+            queryset = queryset.exclude(pk=instance.pk)
+
+        if current_replaces:
+            queryset = queryset | model.objects.filter(pk=current_replaces.pk)
+
+        self.fields["replaces"].queryset = queryset.distinct().order_by("-created_at")
+        self.fields["replaces"].initial = current_replaces
+
+    def clean_replaces(self):
+        replaces = self.cleaned_data.get("replaces")
+        if not replaces:
+            return None
+
+        validate_device_plan_replacement(replaces, self.instance)
+        return replaces
+
+
 class Geometry3DFieldForm(forms.ModelForm):
     """Form class that allows entering a z coordinate for 3d point and location in ewkt format"""
 
@@ -282,7 +323,12 @@ class AdditionalSignRealModelForm(StructuredContentModelFormMixin, SRIDBoundGeom
         }
 
 
-class AdditionalSignPlanModelForm(StructuredContentModelFormMixin, SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
+class AdditionalSignPlanModelForm(
+    ReplaceablePlanModelFormMixin,
+    StructuredContentModelFormMixin,
+    SRIDBoundGeometryFormMixin,
+    Geometry3DFieldForm,
+):
     class Meta:
         model = AdditionalSignPlan
         fields = "__all__"
@@ -291,7 +337,7 @@ class AdditionalSignPlanModelForm(StructuredContentModelFormMixin, SRIDBoundGeom
         }
 
 
-class BarrierPlanModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
+class BarrierPlanModelForm(ReplaceablePlanModelFormMixin, SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
     class Meta:
         model = BarrierPlan
         fields = "__all__"
@@ -303,7 +349,7 @@ class BarrierRealModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
         fields = "__all__"
 
 
-class MountPlanModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
+class MountPlanModelForm(ReplaceablePlanModelFormMixin, SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
     class Meta:
         model = MountPlan
         fields = "__all__"
@@ -327,7 +373,7 @@ class PlanModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
         fields = "__all__"
 
 
-class RoadMarkingPlanModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
+class RoadMarkingPlanModelForm(ReplaceablePlanModelFormMixin, SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
     class Meta:
         model = RoadMarkingPlan
         fields = "__all__"
@@ -339,7 +385,7 @@ class RoadMarkingRealModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
         fields = "__all__"
 
 
-class SignpostPlanModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
+class SignpostPlanModelForm(ReplaceablePlanModelFormMixin, SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
     class Meta:
         model = SignpostPlan
         fields = "__all__"
@@ -401,7 +447,7 @@ class TrafficControlDeviceTypeIconForm(AbstractDeviceTypeIconForm):
         fields = "__all__"
 
 
-class TrafficLightPlanModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
+class TrafficLightPlanModelForm(ReplaceablePlanModelFormMixin, SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
     class Meta:
         model = TrafficLightPlan
         fields = "__all__"
@@ -413,7 +459,7 @@ class TrafficLightRealModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm)
         fields = "__all__"
 
 
-class TrafficSignPlanModelForm(SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
+class TrafficSignPlanModelForm(ReplaceablePlanModelFormMixin, SRIDBoundGeometryFormMixin, Geometry3DFieldForm):
     class Meta:
         model = TrafficSignPlan
         fields = "__all__"

--- a/traffic_control/services/common.py
+++ b/traffic_control/services/common.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Callable, Type
+from typing import Callable, Optional, Type
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
@@ -7,6 +7,7 @@ from django.db import transaction
 from django.db.models import Model, Q
 from django.utils import timezone
 
+from django.utils.translation import gettext_lazy as _
 from traffic_control.enums import Lifecycle
 from traffic_control.mixins.models import SoftDeleteModel
 from users.models import User
@@ -103,6 +104,28 @@ def device_plan_update(
     return instance
 
 
+def validate_device_plan_replacement(old: SoftDeleteModel, new: Optional[SoftDeleteModel]):
+    """
+    Validate that a device plan can be replaced by another device plan.
+
+    :param old: The old device plan to be replaced.
+    :param new: The new device plan that will replace the old one.
+    :raises ValidationError: If the replacement cannot be performed.
+    """
+    if old.replaced_by and (not new or not new.pk or old.replaced_by.pk != new.pk):
+        raise ValidationError(_("Cannot replace a device plan that is already replaced"))
+
+    if new and new.pk:
+        if old.pk == new.pk:
+            raise ValidationError(_("Cannot replace a device plan with itself"))
+
+        check_replaced = old.replaces
+        while check_replaced:
+            if check_replaced.pk == new.pk:
+                raise ValidationError(_("Cannot form a circular replacement chain"))
+            check_replaced = check_replaced.replaces
+
+
 @transaction.atomic
 def device_plan_replace(
     *,
@@ -129,15 +152,7 @@ def device_plan_replace(
     :param unreplace_method: A function to undo a replacement.
     :raises ValidationError: If the replacement cannot be performed between the given device plans.
     """
-    if old.replaced_by:
-        raise ValidationError("Cannot replace a device plan that is already replaced")
-    if old == new:
-        raise ValidationError("Cannot replace a device plan with itself")
-    check_replaced = old.replaces
-    while check_replaced:
-        if check_replaced == new:
-            raise ValidationError("Cannot form a circular replacement chain")
-        check_replaced = check_replaced.replaces
+    validate_device_plan_replacement(old, new)
 
     # Remove older replacement in case of update
     if new.replaces:

--- a/traffic_control/tests/admin/test_admin.py
+++ b/traffic_control/tests/admin/test_admin.py
@@ -5,15 +5,42 @@ from auditlog.models import LogEntry
 from django.conf import settings
 from django.contrib.admin import AdminSite
 from django.contrib.gis.geos import Point
+from django.core.exceptions import ValidationError
 from django.urls import resolve, reverse
 
-from traffic_control.admin import BarrierRealAdmin, TrafficSignPlanAdmin, TrafficSignRealAdmin
+from traffic_control.admin import (
+    AdditionalSignPlanAdmin,
+    BarrierPlanAdmin,
+    BarrierRealAdmin,
+    MountPlanAdmin,
+    RoadMarkingPlanAdmin,
+    SignpostPlanAdmin,
+    TrafficLightPlanAdmin,
+    TrafficSignPlanAdmin,
+    TrafficSignRealAdmin,
+)
 from traffic_control.enums import Lifecycle
-from traffic_control.models import BarrierReal, TrafficSignPlan, TrafficSignReal
+from traffic_control.models import (
+    AdditionalSignPlan,
+    BarrierPlan,
+    BarrierReal,
+    MountPlan,
+    RoadMarkingPlan,
+    SignpostPlan,
+    TrafficLightPlan,
+    TrafficSignPlan,
+    TrafficSignReal,
+)
 from traffic_control.tests.factories import (
     AdditionalSignRealFactory,
+    get_additional_sign_plan_and_replace,
     BarrierRealFactory,
+    get_barrier_plan,
+    get_mount_plan,
     get_owner,
+    get_road_marking_plan,
+    get_signpost_plan,
+    get_traffic_light_plan,
     get_traffic_sign_plan,
     get_traffic_sign_real,
     get_user,
@@ -24,6 +51,17 @@ from traffic_control.tests.utils import MIN_X, MIN_Y
 
 class MockRequest:
     pass
+
+
+replaceable_plan_admin_configs = (
+    (AdditionalSignPlanAdmin, AdditionalSignPlan, get_additional_sign_plan_and_replace),
+    (BarrierPlanAdmin, BarrierPlan, get_barrier_plan),
+    (MountPlanAdmin, MountPlan, get_mount_plan),
+    (RoadMarkingPlanAdmin, RoadMarkingPlan, get_road_marking_plan),
+    (SignpostPlanAdmin, SignpostPlan, get_signpost_plan),
+    (TrafficLightPlanAdmin, TrafficLightPlan, get_traffic_light_plan),
+    (TrafficSignPlanAdmin, TrafficSignPlan, get_traffic_sign_plan),
+)
 
 
 # ------------------------------------------------------------------------------
@@ -184,6 +222,97 @@ def test_traffic_sign_plan_admin_save_model_applies_replacement_through_service(
     assert new_plan.replaces == old_plan
     assert old_plan.replaced_by == new_plan
     assert real.traffic_sign_plan == new_plan
+
+
+@pytest.mark.parametrize(("admin_class", "model", "plan_factory"), replaceable_plan_admin_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_admin_includes_replaces_field_for_all_plan_types(
+    admin_user, admin_site, admin_class, model, plan_factory
+):
+    ma = admin_class(model, admin_site)
+    request = MockRequest()
+    request.user = admin_user
+
+    fieldsets = ma.get_fieldsets(request)
+
+    related_models_fields = next(
+        options["fields"] for _, options in fieldsets if "plan" in options.get("fields", ())
+    )
+    assert "replaces" in related_models_fields
+
+
+@pytest.mark.parametrize(("admin_class", "model", "plan_factory"), replaceable_plan_admin_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_admin_save_model_applies_replacement_through_service_for_all_plan_types(
+    admin_user, admin_site, admin_class, model, plan_factory
+):
+    old_plan = plan_factory()
+    new_plan = plan_factory()
+
+    ma = admin_class(model, admin_site)
+    request = MockRequest()
+    request.user = admin_user
+
+    form = type("DummyForm", (), {"cleaned_data": {"replaces": old_plan}, "changed_data": ["replaces"]})()
+    ma.save_model(request, new_plan, form, change=True)
+
+    old_plan.refresh_from_db()
+    new_plan.refresh_from_db()
+
+    assert new_plan.replaces == old_plan
+    assert old_plan.replaced_by == new_plan
+
+
+@pytest.mark.parametrize(("admin_class", "model", "plan_factory"), replaceable_plan_admin_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_admin_save_model_skips_service_when_replaces_not_changed(
+    admin_user, admin_site, admin_class, model, plan_factory, monkeypatch
+):
+    new_plan = plan_factory()
+    calls = []
+
+    def fake_service(*, instance, data):
+        calls.append((instance.pk, data))
+
+    monkeypatch.setattr(admin_class, "plan_update_service", staticmethod(fake_service))
+
+    ma = admin_class(model, admin_site)
+    request = MockRequest()
+    request.user = admin_user
+    form = type("DummyForm", (), {"cleaned_data": {"replaces": None}, "changed_data": []})()
+
+    ma.save_model(request, new_plan, form, change=True)
+
+    assert calls == []
+    new_plan.refresh_from_db()
+    assert new_plan.replaces is None
+
+
+@pytest.mark.parametrize(("admin_class", "model", "plan_factory"), replaceable_plan_admin_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_admin_save_model_propagates_service_validation_error(
+    admin_user, admin_site, admin_class, model, plan_factory, monkeypatch
+):
+    old_plan = plan_factory()
+    new_plan = plan_factory()
+
+    def fake_service(*, instance, data):
+        raise ValidationError("Cannot replace a device plan that is already replaced")
+
+    monkeypatch.setattr(admin_class, "plan_update_service", staticmethod(fake_service))
+
+    ma = admin_class(model, admin_site)
+    request = MockRequest()
+    request.user = admin_user
+    form = type("DummyForm", (), {"cleaned_data": {"replaces": old_plan}, "changed_data": ["replaces"]})()
+
+    with pytest.raises(ValidationError, match="Cannot replace a device plan that is already replaced"):
+        ma.save_model(request, new_plan, form, change=True)
+
+    old_plan.refresh_from_db()
+    new_plan.refresh_from_db()
+    assert old_plan.replaced_by is None
+    assert new_plan.replaces is None
 
 
 # ------------------------------------------------------------------------------

--- a/traffic_control/tests/admin/test_admin.py
+++ b/traffic_control/tests/admin/test_admin.py
@@ -7,13 +7,15 @@ from django.contrib.admin import AdminSite
 from django.contrib.gis.geos import Point
 from django.urls import resolve, reverse
 
-from traffic_control.admin import BarrierRealAdmin, TrafficSignRealAdmin
+from traffic_control.admin import BarrierRealAdmin, TrafficSignPlanAdmin, TrafficSignRealAdmin
 from traffic_control.enums import Lifecycle
-from traffic_control.models import BarrierReal, TrafficSignReal
+from traffic_control.models import BarrierReal, TrafficSignPlan, TrafficSignReal
 from traffic_control.tests.factories import (
     AdditionalSignRealFactory,
     BarrierRealFactory,
     get_owner,
+    get_traffic_sign_plan,
+    get_traffic_sign_real,
     get_user,
     TrafficSignRealFactory,
 )
@@ -146,6 +148,42 @@ def test_save_model_set_updated_by_for_updating(admin_user, standard_user, traff
 
     assert traffic_sign_real.created_by == standard_user
     assert traffic_sign_real.updated_by == admin_user
+
+
+@pytest.mark.django_db
+def test_traffic_sign_plan_admin_includes_replaces_field(admin_user, admin_site):
+    ma = TrafficSignPlanAdmin(TrafficSignPlan, admin_site)
+    request = MockRequest()
+    request.user = admin_user
+
+    fieldsets = ma.get_fieldsets(request)
+
+    related_models_fields = next(
+        options["fields"] for _, options in fieldsets if "plan" in options.get("fields", ())
+    )
+    assert "replaces" in related_models_fields
+
+
+@pytest.mark.django_db
+def test_traffic_sign_plan_admin_save_model_applies_replacement_through_service(admin_user, admin_site):
+    old_plan = get_traffic_sign_plan()
+    new_plan = get_traffic_sign_plan()
+    real = get_traffic_sign_real(traffic_sign_plan=old_plan)
+
+    ma = TrafficSignPlanAdmin(TrafficSignPlan, admin_site)
+    request = MockRequest()
+    request.user = admin_user
+
+    form = type("DummyForm", (), {"cleaned_data": {"replaces": old_plan}, "changed_data": ["replaces"]})()
+    ma.save_model(request, new_plan, form, change=True)
+
+    old_plan.refresh_from_db()
+    new_plan.refresh_from_db()
+    real.refresh_from_db()
+
+    assert new_plan.replaces == old_plan
+    assert old_plan.replaced_by == new_plan
+    assert real.traffic_sign_plan == new_plan
 
 
 # ------------------------------------------------------------------------------

--- a/traffic_control/tests/factories.py
+++ b/traffic_control/tests/factories.py
@@ -224,6 +224,7 @@ def get_barrier_real(
 ) -> BarrierReal:
     user = get_user("test_user")
     barrier_plan = barrier_plan or get_barrier_plan()
+    device_type = device_type or barrier_plan.device_type
 
     return BarrierReal.objects.create(
         device_type=device_type,
@@ -419,10 +420,12 @@ def get_road_marking_real(
     traffic_sign_real=None,
 ) -> RoadMarkingReal:
     user = get_user("test_user")
+    road_marking_plan = road_marking_plan or get_road_marking_plan()
+    device_type = device_type or road_marking_plan.device_type
 
     return RoadMarkingReal.objects.get_or_create(
         device_type=device_type,
-        road_marking_plan=road_marking_plan or get_road_marking_plan(),
+        road_marking_plan=road_marking_plan,
         value="30",
         color=RoadMarkingColor.WHITE,
         location=location or test_point,
@@ -684,9 +687,11 @@ def get_traffic_sign_real(
     mount_real=None,
 ) -> TrafficSignReal:
     user = get_user("test_user")
+    traffic_sign_plan = traffic_sign_plan or get_traffic_sign_plan()
+    device_type = device_type or traffic_sign_plan.device_type
 
     return TrafficSignReal.objects.get_or_create(
-        traffic_sign_plan=traffic_sign_plan or get_traffic_sign_plan(),
+        traffic_sign_plan=traffic_sign_plan,
         device_type=device_type,
         location=location or test_point_3d,
         installation_date=datetime.date(2020, 1, 1),

--- a/traffic_control/tests/test_forms.py
+++ b/traffic_control/tests/test_forms.py
@@ -9,9 +9,25 @@ from django.test import TestCase
 from enumfields import Enum, EnumIntegerField
 
 from traffic_control.enums import Lifecycle
-from traffic_control.forms import AdminEnumChoiceField, TrafficSignPlanModelForm, TrafficSignRealModelForm
+from traffic_control.forms import (
+    AdminEnumChoiceField,
+    AdditionalSignPlanModelForm,
+    BarrierPlanModelForm,
+    MountPlanModelForm,
+    RoadMarkingPlanModelForm,
+    SignpostPlanModelForm,
+    TrafficLightPlanModelForm,
+    TrafficSignPlanModelForm,
+    TrafficSignRealModelForm,
+)
 from traffic_control.tests.factories import (
+    get_additional_sign_plan_and_replace,
+    get_barrier_plan,
+    get_mount_plan,
     get_traffic_sign_plan,
+    get_road_marking_plan,
+    get_signpost_plan,
+    get_traffic_light_plan,
     get_owner,
     get_user,
     TrafficControlDeviceTypeFactory,
@@ -34,6 +50,17 @@ class _TestEnum(Enum):
 
 class _TestForm(forms.Form):
     test_field = EnumIntegerField(_TestEnum).formfield(choices_form_class=AdminEnumChoiceField)
+
+
+replaceable_plan_form_configs = (
+    (AdditionalSignPlanModelForm, get_additional_sign_plan_and_replace),
+    (BarrierPlanModelForm, get_barrier_plan),
+    (MountPlanModelForm, get_mount_plan),
+    (RoadMarkingPlanModelForm, get_road_marking_plan),
+    (SignpostPlanModelForm, get_signpost_plan),
+    (TrafficLightPlanModelForm, get_traffic_light_plan),
+    (TrafficSignPlanModelForm, get_traffic_sign_plan),
+)
 
 
 def test_admin_enum_choice_field():
@@ -160,3 +187,75 @@ def test_traffic_sign_plan_form_clean_replaces_rejects_circular_chain():
 
     with pytest.raises(ValidationError, match="Cannot form a circular replacement chain"):
         form.clean_replaces()
+
+
+@pytest.mark.parametrize(("form_class", "plan_factory"), replaceable_plan_form_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_form_replaces_initial_and_queryset_for_all_plan_types(form_class, plan_factory):
+    replaced_plan = plan_factory()
+    replacing_plan = plan_factory(replaces=replaced_plan)
+    free_plan = plan_factory()
+
+    form = form_class(instance=replacing_plan)
+
+    assert form.fields["replaces"].initial == replaced_plan
+    assert replaced_plan in form.fields["replaces"].queryset
+    assert free_plan in form.fields["replaces"].queryset
+    assert replacing_plan not in form.fields["replaces"].queryset
+
+
+@pytest.mark.parametrize(("form_class", "plan_factory"), replaceable_plan_form_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_form_clean_replaces_rejects_self_replacement_for_all_plan_types(form_class, plan_factory):
+    plan = plan_factory()
+    form = form_class(instance=plan)
+    form.cleaned_data = {"replaces": plan}
+
+    with pytest.raises(ValidationError, match="Cannot replace a device plan with itself"):
+        form.clean_replaces()
+
+
+@pytest.mark.parametrize(("form_class", "plan_factory"), replaceable_plan_form_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_form_clean_rejects_circular_chain_for_all_plan_types(form_class, plan_factory):
+    plan_a = plan_factory()
+    plan_b = plan_factory(replaces=plan_a)
+    plan_c = plan_factory(replaces=plan_b)
+
+    form = form_class(instance=plan_a)
+    form.cleaned_data = {"replaces": plan_c}
+
+    with pytest.raises(ValidationError, match="Cannot form a circular replacement chain"):
+        form.clean_replaces()
+
+
+@pytest.mark.parametrize(("form_class", "plan_factory"), replaceable_plan_form_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_form_clean_replaces_rejects_already_replaced_target(form_class, plan_factory):
+    already_replaced = plan_factory()
+    replacer = plan_factory(replaces=already_replaced)
+    another_candidate = plan_factory()
+
+    form = form_class(instance=another_candidate)
+    form.cleaned_data = {"replaces": already_replaced}
+
+    with pytest.raises(ValidationError, match="Cannot replace a device plan that is already replaced"):
+        form.clean_replaces()
+
+    already_replaced.refresh_from_db()
+    replacer.refresh_from_db()
+    another_candidate.refresh_from_db()
+    assert already_replaced.replaced_by == replacer
+    assert another_candidate.replaces is None
+
+
+@pytest.mark.parametrize(("form_class", "plan_factory"), replaceable_plan_form_configs)
+@pytest.mark.django_db
+def test_replaceable_plan_form_clean_replaces_allows_clearing_replacement(form_class, plan_factory):
+    replaced_plan = plan_factory()
+    replacing_plan = plan_factory(replaces=replaced_plan)
+
+    form = form_class(instance=replacing_plan)
+    form.cleaned_data = {"replaces": None}
+
+    assert form.clean_replaces() is None

--- a/traffic_control/tests/test_forms.py
+++ b/traffic_control/tests/test_forms.py
@@ -1,14 +1,17 @@
+import pytest
 from enum import member
 
 from django.conf import settings
 from django.contrib.gis.geos import Point
+from django.core.exceptions import ValidationError
 from django.forms import forms
 from django.test import TestCase
 from enumfields import Enum, EnumIntegerField
 
 from traffic_control.enums import Lifecycle
-from traffic_control.forms import AdminEnumChoiceField, TrafficSignRealModelForm
+from traffic_control.forms import AdminEnumChoiceField, TrafficSignPlanModelForm, TrafficSignRealModelForm
 from traffic_control.tests.factories import (
+    get_traffic_sign_plan,
     get_owner,
     get_user,
     TrafficControlDeviceTypeFactory,
@@ -120,3 +123,40 @@ class TrafficSignRealModelFormTestCase(TestCase):
         self.assertTrue(form.is_valid())
         instance = form.save()
         self.assertEqual(instance.location, Point(MIN_X + 10, MIN_Y + 10, 20, srid=settings.SRID))
+
+
+@pytest.mark.django_db
+def test_traffic_sign_plan_form_replaces_initial_and_queryset():
+    replaced_plan = get_traffic_sign_plan()
+    replacing_plan = get_traffic_sign_plan(replaces=replaced_plan)
+    free_plan = get_traffic_sign_plan()
+
+    form = TrafficSignPlanModelForm(instance=replacing_plan)
+
+    assert form.fields["replaces"].initial == replaced_plan
+    assert replaced_plan in form.fields["replaces"].queryset
+    assert free_plan in form.fields["replaces"].queryset
+    assert replacing_plan not in form.fields["replaces"].queryset
+
+
+@pytest.mark.django_db
+def test_traffic_sign_plan_form_clean_replaces_rejects_self_replacement():
+    plan = get_traffic_sign_plan()
+    form = TrafficSignPlanModelForm(instance=plan)
+    form.cleaned_data = {"replaces": plan}
+
+    with pytest.raises(ValidationError, match="Cannot replace a device plan with itself"):
+        form.clean_replaces()
+
+
+@pytest.mark.django_db
+def test_traffic_sign_plan_form_clean_replaces_rejects_circular_chain():
+    plan_a = get_traffic_sign_plan()
+    plan_b = get_traffic_sign_plan(replaces=plan_a)
+    plan_c = get_traffic_sign_plan(replaces=plan_b)
+
+    form = TrafficSignPlanModelForm(instance=plan_a)
+    form.cleaned_data = {"replaces": plan_c}
+
+    with pytest.raises(ValidationError, match="Cannot form a circular replacement chain"):
+        form.clean_replaces()


### PR DESCRIPTION
This PR addresses the following TODO:

Modifying replacements can be allowed when Admin UI uses service layer function

To solve this, I updated the Admin UI flow so plan replacement changes are handled through the service layer instead of direct model writes. This keeps the admin behavior aligned with the business rules already enforced in the service layer and API.

What was done:

- Added support for editing `replaces` directly from the admin form.
- Routed replacement updates through the plan update service.
- Preserved service-layer validation for all replacement rules.
- Added automated test coverage for both success and error scenarios.
- Preserved the original TrafficSign-focused tests and added new tests for broader replaceable plan coverage.

This change allows replacement updates from the Admin UI while keeping the logic centralized and consistent.

About me:
My name is Romario Jonas, but you can call me Roma. I am a Brazilian Full Stack developer contributing to Finnish open-source projects to strengthen my technical skills in an international environment, improve my English, and learn more about the local engineering culture. My goal is to learn through real collaboration and contribute in a respectful way.

Thank you for your time and feedback.
