### PR TITLE
feat: Clean up traffic sign that were migrated to other tables

### DIFF
--- a/traffic_control/management/commands/cleanup_migrated_traffic_signs.py
+++ b/traffic_control/management/commands/cleanup_migrated_traffic_signs.py
@@ -1,0 +1,200 @@
+"""
+Management command to hard-delete traffic signs previously soft-deleted by migration commands.
+
+Cleans up TrafficSignPlan and TrafficSignReal objects that were soft-deleted by:
+- move_ticket_machines_to_additional_signs
+- move_traffic_signs_to_signposts
+
+Candidates are identified through the respective migration run records.
+Supports --dry-run for safe previewing and --migration-run for partial cleanup.
+"""
+import logging
+from typing import Optional, Type
+
+from django.core.management.base import BaseCommand, CommandParser
+from django.db.models import Model
+
+from traffic_control.models.signpost_migration import SignpostMigrationPlanRecord, SignpostMigrationRealRecord
+from traffic_control.models.ticket_machine_migration import (
+    TicketMachineMigrationPlanRecord,
+    TicketMachineMigrationRealRecord,
+)
+from traffic_control.models.traffic_sign import TrafficSignPlan, TrafficSignReal
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Hard-delete traffic signs soft-deleted by the ticket-machine and signpost migration commands."""
+
+    help = (
+        "Hard-delete TrafficSignPlan/TrafficSignReal objects that were soft-deleted by "
+        "move_ticket_machines_to_additional_signs or move_traffic_signs_to_signposts."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        """Add command-line arguments.
+
+        Args:
+            parser (CommandParser): The argument parser to add arguments to.
+
+        Returns:
+            None
+        """
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview what would be deleted without making any changes.",
+        )
+        parser.add_argument(
+            "--ticket-machine-run",
+            type=int,
+            metavar="RUN_ID",
+            help="Limit cleanup to a specific TicketMachineMigrationRun ID.",
+        )
+        parser.add_argument(
+            "--signpost-run",
+            type=int,
+            metavar="RUN_ID",
+            help="Limit cleanup to a specific SignpostMigrationRun ID.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        """Execute the cleanup command.
+
+        Args:
+            *args: Positional arguments (unused).
+            **options: Parsed command-line options.
+
+        Returns:
+            None
+        """
+        dry_run: bool = options["dry_run"]
+        ticket_machine_run_id: Optional[int] = options["ticket_machine_run"]
+        signpost_run_id: Optional[int] = options["signpost_run"]
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN MODE - No changes will be made"))
+
+        plan_ids = self._collect_plan_ids(ticket_machine_run_id, signpost_run_id)
+        real_ids = self._collect_real_ids(ticket_machine_run_id, signpost_run_id)
+
+        plans_qs = TrafficSignPlan.objects.filter(id__in=plan_ids, is_active=False)
+        reals_qs = TrafficSignReal.objects.filter(id__in=real_ids, is_active=False)
+
+        plans_count = plans_qs.count()
+        reals_count = reals_qs.count()
+
+        self._report_candidates(plans_count, reals_count)
+
+        if not dry_run:
+            self._delete_objects(plans_qs, reals_qs)
+            self._report_completion(plans_count, reals_count)
+        else:
+            self.stdout.write(self.style.WARNING("\nDRY RUN COMPLETE - No changes were made"))
+
+    # ── Collection helpers ────────────────────────────────────────────────────
+
+    def _collect_plan_ids(
+        self,
+        ticket_machine_run_id: Optional[int],
+        signpost_run_id: Optional[int],
+    ) -> set:
+        """Collect TrafficSignPlan UUIDs eligible for hard-deletion.
+
+        Args:
+            ticket_machine_run_id (Optional[int]): Limit to a specific TicketMachineMigrationRun.
+            signpost_run_id (Optional[int]): Limit to a specific SignpostMigrationRun.
+
+        Returns:
+            set: Set of UUIDs for eligible TrafficSignPlan objects.
+        """
+        ticket_ids = self._collect_ids_from_record_model(TicketMachineMigrationPlanRecord, ticket_machine_run_id)
+        signpost_ids = self._collect_ids_from_record_model(SignpostMigrationPlanRecord, signpost_run_id)
+        return ticket_ids | signpost_ids
+
+    def _collect_real_ids(
+        self,
+        ticket_machine_run_id: Optional[int],
+        signpost_run_id: Optional[int],
+    ) -> set:
+        """Collect TrafficSignReal UUIDs eligible for hard-deletion.
+
+        Args:
+            ticket_machine_run_id (Optional[int]): Limit to a specific TicketMachineMigrationRun.
+            signpost_run_id (Optional[int]): Limit to a specific SignpostMigrationRun.
+
+        Returns:
+            set: Set of UUIDs for eligible TrafficSignReal objects.
+        """
+        ticket_ids = self._collect_ids_from_record_model(TicketMachineMigrationRealRecord, ticket_machine_run_id)
+        signpost_ids = self._collect_ids_from_record_model(SignpostMigrationRealRecord, signpost_run_id)
+        return ticket_ids | signpost_ids
+
+    # ── Per-source ID collectors ──────────────────────────────────────────────
+
+    def _collect_ids_from_record_model(self, model: Type[Model], run_id: Optional[int]) -> set:
+        """Return original_ids from a migration record model for completed soft-delete runs.
+
+        Args:
+            model (Type[Model]): A migration record model class with a ``migration_run`` FK
+                and ``original_id`` / ``new_id`` fields.
+            run_id (Optional[int]): Specific migration run ID to filter by, or None for all runs.
+
+        Returns:
+            set: Set of UUIDs eligible for hard-deletion.
+        """
+        qs = model.objects.filter(
+            migration_run__dry_run=False,
+            migration_run__hard_delete=False,
+            migration_run__success=True,
+            new_id__isnull=False,
+        )
+        if run_id is not None:
+            qs = qs.filter(migration_run_id=run_id)
+        return set(qs.values_list("original_id", flat=True))
+
+    # ── Output helpers ────────────────────────────────────────────────────────
+
+    def _report_candidates(self, plans_count: int, reals_count: int) -> None:
+        """Write candidate counts to stdout.
+
+        Args:
+            plans_count (int): Number of TrafficSignPlan objects to delete.
+            reals_count (int): Number of TrafficSignReal objects to delete.
+
+        Returns:
+            None
+        """
+        self.stdout.write(f"\nFound {plans_count} TrafficSignPlan object(s) eligible for hard-deletion")
+        self.stdout.write(f"Found {reals_count} TrafficSignReal object(s) eligible for hard-deletion")
+
+    def _delete_objects(self, plans_qs, reals_qs) -> None:
+        """Hard-delete the supplied querysets.
+
+        Args:
+            plans_qs: QuerySet of TrafficSignPlan objects to delete.
+            reals_qs: QuerySet of TrafficSignReal objects to delete.
+
+        Returns:
+            None
+        """
+        deleted_plans, _ = plans_qs.delete()
+        logger.info("Hard-deleted %d TrafficSignPlan objects", deleted_plans)
+
+        deleted_reals, _ = reals_qs.delete()
+        logger.info("Hard-deleted %d TrafficSignReal objects", deleted_reals)
+
+    def _report_completion(self, plans_count: int, reals_count: int) -> None:
+        """Write completion summary to stdout.
+
+        Args:
+            plans_count (int): Number of TrafficSignPlan objects deleted.
+            reals_count (int): Number of TrafficSignReal objects deleted.
+
+        Returns:
+            None
+        """
+        self.stdout.write(self.style.SUCCESS(f"\n✓ Hard-deleted {plans_count} TrafficSignPlan object(s)"))
+        self.stdout.write(self.style.SUCCESS(f"✓ Hard-deleted {reals_count} TrafficSignReal object(s)"))
+        self.stdout.write(self.style.SUCCESS("\n✓ Cleanup completed successfully!"))

--- a/traffic_control/tests/management/commands/test_cleanup_migrated_traffic_signs.py
+++ b/traffic_control/tests/management/commands/test_cleanup_migrated_traffic_signs.py
@@ -1,0 +1,543 @@
+"""Tests for cleanup_migrated_traffic_signs management command."""
+import uuid
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.utils import timezone
+
+from traffic_control.constants import SIGNPOST_CODES, TICKET_MACHINE_CODES
+from traffic_control.enums import DeviceTypeTargetModel
+from traffic_control.models.signpost_migration import (
+    SignpostMigrationPlanRecord,
+    SignpostMigrationRealRecord,
+    SignpostMigrationRun,
+)
+from traffic_control.models.ticket_machine_migration import (
+    TicketMachineMigrationPlanRecord,
+    TicketMachineMigrationRealRecord,
+    TicketMachineMigrationRun,
+)
+from traffic_control.models.traffic_sign import TrafficSignPlan, TrafficSignReal
+from traffic_control.tests.factories import (
+    TrafficControlDeviceTypeFactory,
+    TrafficSignPlanFactory,
+    TrafficSignRealFactory,
+)
+
+User = get_user_model()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def system_user(db):
+    """Return or create the system user required by migration commands.
+
+    Args:
+        db: pytest-django database fixture.
+
+    Returns:
+        User: The system user instance.
+    """
+    return User.objects.get_or_create(username="system", defaults={"is_active": True})[0]
+
+
+@pytest.fixture
+def ticket_machine_device_type(db):
+    """Create a single ticket-machine device type.
+
+    Args:
+        db: pytest-django database fixture.
+
+    Returns:
+        TrafficControlDeviceType: Device type with code from TICKET_MACHINE_CODES.
+    """
+    return TrafficControlDeviceTypeFactory(
+        code=TICKET_MACHINE_CODES[0],
+        target_model=DeviceTypeTargetModel.TRAFFIC_SIGN,
+    )
+
+
+@pytest.fixture
+def signpost_device_type(db):
+    """Create a single signpost device type.
+
+    Args:
+        db: pytest-django database fixture.
+
+    Returns:
+        TrafficControlDeviceType: Device type with code from SIGNPOST_CODES.
+    """
+    return TrafficControlDeviceTypeFactory(
+        code=SIGNPOST_CODES[0],
+        target_model=DeviceTypeTargetModel.TRAFFIC_SIGN,
+    )
+
+
+def _make_ticket_machine_run(user, *, dry_run: bool = False, hard_delete: bool = False) -> TicketMachineMigrationRun:
+    """Create a TicketMachineMigrationRun with sensible defaults.
+
+    Args:
+        user: The User to set as executed_by.
+        dry_run (bool): Whether to mark as dry run.
+        hard_delete (bool): Whether to mark as hard-delete mode.
+
+    Returns:
+        TicketMachineMigrationRun: The created run instance.
+    """
+    return TicketMachineMigrationRun.objects.create(
+        executed_by=user,
+        dry_run=dry_run,
+        hard_delete=hard_delete,
+        success=True,
+        completed_at=timezone.now(),
+    )
+
+
+def _make_signpost_run(user, *, dry_run: bool = False, hard_delete: bool = False) -> SignpostMigrationRun:
+    """Create a SignpostMigrationRun with sensible defaults.
+
+    Args:
+        user: The User to set as executed_by.
+        dry_run (bool): Whether to mark as dry run.
+        hard_delete (bool): Whether to mark as hard-delete mode.
+
+    Returns:
+        SignpostMigrationRun: The created run instance.
+    """
+    return SignpostMigrationRun.objects.create(
+        executed_by=user,
+        dry_run=dry_run,
+        hard_delete=hard_delete,
+        success=True,
+        completed_at=timezone.now(),
+    )
+
+
+def _soft_delete_plan(plan: TrafficSignPlan, user) -> TrafficSignPlan:
+    """Soft-delete a plan and return it refreshed from the database.
+
+    Args:
+        plan (TrafficSignPlan): The plan instance to soft-delete.
+        user: The user to record as the deleter.
+
+    Returns:
+        TrafficSignPlan: Refreshed plan with is_active=False.
+    """
+    plan.soft_delete(user)
+    plan.refresh_from_db()
+    return plan
+
+
+def _soft_delete_real(real: TrafficSignReal, user) -> TrafficSignReal:
+    """Soft-delete a real and return it refreshed from the database.
+
+    Args:
+        real (TrafficSignReal): The real instance to soft-delete.
+        user: The user to record as the deleter.
+
+    Returns:
+        TrafficSignReal: Refreshed real with is_active=False.
+    """
+    real.soft_delete(user)
+    real.refresh_from_db()
+    return real
+
+
+# ── Ticket machine plan tests ─────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cleanup_hard_deletes_ticket_machine_plans(system_user, ticket_machine_device_type):
+    """Plans soft-deleted by ticket machine migration are hard-deleted by cleanup.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+
+    Returns:
+        None
+    """
+    plan = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    plan_id = plan.id
+    _soft_delete_plan(plan, system_user)
+
+    run = _make_ticket_machine_run(system_user)
+    new_id = uuid.uuid4()
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=run,
+        original_traffic_sign_plan=plan,
+        original_id=plan_id,
+        new_id=new_id,
+        device_type_code=ticket_machine_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", stdout=StringIO())
+
+    assert not TrafficSignPlan.objects.filter(id=plan_id).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_dry_run_skips_ticket_machine_plans(system_user, ticket_machine_device_type):
+    """Dry-run mode reports candidates without hard-deleting ticket machine plans.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+
+    Returns:
+        None
+    """
+    plan = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    plan_id = plan.id
+    _soft_delete_plan(plan, system_user)
+
+    run = _make_ticket_machine_run(system_user)
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=run,
+        original_traffic_sign_plan=plan,
+        original_id=plan_id,
+        new_id=uuid.uuid4(),
+        device_type_code=ticket_machine_device_type.code,
+    )
+
+    out = StringIO()
+    call_command("cleanup_migrated_traffic_signs", "--dry-run", stdout=out)
+
+    assert TrafficSignPlan.objects.filter(id=plan_id).exists()
+    assert "DRY RUN" in out.getvalue()
+
+
+# ── Ticket machine real tests ─────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cleanup_hard_deletes_ticket_machine_reals(system_user, ticket_machine_device_type):
+    """Reals soft-deleted by ticket machine migration are hard-deleted by cleanup.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+
+    Returns:
+        None
+    """
+    real = TrafficSignRealFactory(device_type=ticket_machine_device_type)
+    real_id = real.id
+    _soft_delete_real(real, system_user)
+
+    run = _make_ticket_machine_run(system_user)
+    TicketMachineMigrationRealRecord.objects.create(
+        migration_run=run,
+        original_traffic_sign_real=real,
+        original_id=real_id,
+        new_id=uuid.uuid4(),
+        device_type_code=ticket_machine_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", stdout=StringIO())
+
+    assert not TrafficSignReal.objects.filter(id=real_id).exists()
+
+
+# ── Signpost plan tests ───────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cleanup_hard_deletes_signpost_plans(system_user, signpost_device_type):
+    """Plans soft-deleted by signpost migration are hard-deleted by cleanup.
+
+    Args:
+        system_user: The system user fixture.
+        signpost_device_type: A signpost device type fixture.
+
+    Returns:
+        None
+    """
+    plan = TrafficSignPlanFactory(device_type=signpost_device_type)
+    plan_id = plan.id
+    _soft_delete_plan(plan, system_user)
+
+    run = _make_signpost_run(system_user)
+    SignpostMigrationPlanRecord.objects.create(
+        migration_run=run,
+        original_traffic_sign_plan=plan,
+        original_id=plan_id,
+        new_id=uuid.uuid4(),
+        device_type_code=signpost_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", stdout=StringIO())
+
+    assert not TrafficSignPlan.objects.filter(id=plan_id).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_hard_deletes_signpost_reals(system_user, signpost_device_type):
+    """Reals soft-deleted by signpost migration are hard-deleted by cleanup.
+
+    Args:
+        system_user: The system user fixture.
+        signpost_device_type: A signpost device type fixture.
+
+    Returns:
+        None
+    """
+    real = TrafficSignRealFactory(device_type=signpost_device_type)
+    real_id = real.id
+    _soft_delete_real(real, system_user)
+
+    run = _make_signpost_run(system_user)
+    SignpostMigrationRealRecord.objects.create(
+        migration_run=run,
+        original_traffic_sign_real=real,
+        original_id=real_id,
+        new_id=uuid.uuid4(),
+        device_type_code=signpost_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", stdout=StringIO())
+
+    assert not TrafficSignReal.objects.filter(id=real_id).exists()
+
+
+# ── Exclusion tests ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cleanup_excludes_hard_delete_run_records(system_user, ticket_machine_device_type):
+    """Records from hard-delete runs are not considered for cleanup.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+
+    Returns:
+        None
+    """
+    plan = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    plan_id = plan.id
+    _soft_delete_plan(plan, system_user)
+
+    hard_delete_run = _make_ticket_machine_run(system_user, hard_delete=True)
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=hard_delete_run,
+        original_id=plan_id,
+        new_id=uuid.uuid4(),
+        device_type_code=ticket_machine_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", stdout=StringIO())
+
+    # Plan is still present (soft-deleted but not hard-deleted by cleanup)
+    assert TrafficSignPlan.objects.filter(id=plan_id).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_excludes_dry_run_records(system_user, ticket_machine_device_type):
+    """Records from dry-run migrations are not considered for cleanup.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+
+    Returns:
+        None
+    """
+    plan = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    plan_id = plan.id
+
+    dry_run = _make_ticket_machine_run(system_user, dry_run=True)
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=dry_run,
+        original_id=plan_id,
+        new_id=None,  # dry-run: new_id is null
+        device_type_code=ticket_machine_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", stdout=StringIO())
+
+    assert TrafficSignPlan.objects.filter(id=plan_id).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_excludes_active_signs(system_user, ticket_machine_device_type):
+    """Active (non-soft-deleted) traffic signs are never hard-deleted.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+
+    Returns:
+        None
+    """
+    plan = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    plan_id = plan.id
+    # NOT soft-deleted
+
+    run = _make_ticket_machine_run(system_user)
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=run,
+        original_id=plan_id,
+        new_id=uuid.uuid4(),
+        device_type_code=ticket_machine_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", stdout=StringIO())
+
+    # Still active, not deleted
+    assert TrafficSignPlan.objects.filter(id=plan_id, is_active=True).exists()
+
+
+# ── Partial cleanup tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cleanup_partial_ticket_machine_run(system_user, ticket_machine_device_type):
+    """--ticket-machine-run limits cleanup to the specified run.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+
+    Returns:
+        None
+    """
+    plan_a = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    plan_b = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    _soft_delete_plan(plan_a, system_user)
+    _soft_delete_plan(plan_b, system_user)
+
+    run_1 = _make_ticket_machine_run(system_user)
+    run_2 = _make_ticket_machine_run(system_user)
+
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=run_1,
+        original_id=plan_a.id,
+        new_id=uuid.uuid4(),
+        device_type_code=ticket_machine_device_type.code,
+    )
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=run_2,
+        original_id=plan_b.id,
+        new_id=uuid.uuid4(),
+        device_type_code=ticket_machine_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", f"--ticket-machine-run={run_1.id}", stdout=StringIO())
+
+    assert not TrafficSignPlan.objects.filter(id=plan_a.id).exists()
+    assert TrafficSignPlan.objects.filter(id=plan_b.id).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_partial_signpost_run(system_user, signpost_device_type):
+    """--signpost-run limits cleanup to the specified run.
+
+    Args:
+        system_user: The system user fixture.
+        signpost_device_type: A signpost device type fixture.
+
+    Returns:
+        None
+    """
+    plan_a = TrafficSignPlanFactory(device_type=signpost_device_type)
+    plan_b = TrafficSignPlanFactory(device_type=signpost_device_type)
+    _soft_delete_plan(plan_a, system_user)
+    _soft_delete_plan(plan_b, system_user)
+
+    run_1 = _make_signpost_run(system_user)
+    run_2 = _make_signpost_run(system_user)
+
+    SignpostMigrationPlanRecord.objects.create(
+        migration_run=run_1,
+        original_id=plan_a.id,
+        new_id=uuid.uuid4(),
+        device_type_code=signpost_device_type.code,
+    )
+    SignpostMigrationPlanRecord.objects.create(
+        migration_run=run_2,
+        original_id=plan_b.id,
+        new_id=uuid.uuid4(),
+        device_type_code=signpost_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", f"--signpost-run={run_1.id}", stdout=StringIO())
+
+    assert not TrafficSignPlan.objects.filter(id=plan_a.id).exists()
+    assert TrafficSignPlan.objects.filter(id=plan_b.id).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_both_sources_in_one_invocation(system_user, ticket_machine_device_type, signpost_device_type):
+    """Cleanup handles ticket machine and signpost plans in one invocation.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+        signpost_device_type: A signpost device type fixture.
+
+    Returns:
+        None
+    """
+    tm_plan = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    sp_plan = TrafficSignPlanFactory(device_type=signpost_device_type)
+    _soft_delete_plan(tm_plan, system_user)
+    _soft_delete_plan(sp_plan, system_user)
+
+    tm_run = _make_ticket_machine_run(system_user)
+    sp_run = _make_signpost_run(system_user)
+
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=tm_run,
+        original_id=tm_plan.id,
+        new_id=uuid.uuid4(),
+        device_type_code=ticket_machine_device_type.code,
+    )
+    SignpostMigrationPlanRecord.objects.create(
+        migration_run=sp_run,
+        original_id=sp_plan.id,
+        new_id=uuid.uuid4(),
+        device_type_code=signpost_device_type.code,
+    )
+
+    call_command("cleanup_migrated_traffic_signs", stdout=StringIO())
+
+    assert not TrafficSignPlan.objects.filter(id=tm_plan.id).exists()
+    assert not TrafficSignPlan.objects.filter(id=sp_plan.id).exists()
+
+
+# ── Output / reporting tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cleanup_output_reports_counts(system_user, ticket_machine_device_type):
+    """Command output reports the number of candidates found.
+
+    Args:
+        system_user: The system user fixture.
+        ticket_machine_device_type: A ticket-machine device type fixture.
+
+    Returns:
+        None
+    """
+    plan = TrafficSignPlanFactory(device_type=ticket_machine_device_type)
+    _soft_delete_plan(plan, system_user)
+
+    run = _make_ticket_machine_run(system_user)
+    TicketMachineMigrationPlanRecord.objects.create(
+        migration_run=run,
+        original_id=plan.id,
+        new_id=uuid.uuid4(),
+        device_type_code=ticket_machine_device_type.code,
+    )
+
+    out = StringIO()
+    call_command("cleanup_migrated_traffic_signs", stdout=out)
+
+    output = out.getvalue()
+    assert "1" in output
+    assert "TrafficSignPlan" in output


### PR DESCRIPTION
* Clean up soft-deleted traffic sign that were moved to:
	* Signposts table by command move_traffic_signs_to_signpost
	* AdditionalSign by command move_ticket_machines_to_additional_signs
* Gathers uuids from migration run tables that were run as soft-delete
* delete bogus management command traffic_control/management/commands/move_ticket_machines_to_additional_signs_new.py

Refs: LIIK-952