### PR TITLE
feat: revert operation Streetscan2025 data import

### DIFF
--- a/traffic_control/management/commands/revert_import_streetscan_signs_v2.py
+++ b/traffic_control/management/commands/revert_import_streetscan_signs_v2.py
@@ -1,0 +1,319 @@
+import argparse
+import json
+from collections import defaultdict
+from datetime import datetime
+from typing import Literal
+
+from auditlog.context import set_actor
+from django.apps import apps
+from django.core.management import BaseCommand, CommandParser
+from django.db import transaction
+from django.utils import timezone
+
+from traffic_control.models import AdditionalSignReal, MountReal, SignpostReal, TrafficSignReal
+from users.models import User
+from users.utils import get_system_user
+
+# Types
+ModelAffectedByImport = AdditionalSignReal | MountReal | SignpostReal | TrafficSignReal
+ActionType = Literal["create", "deactivate", "update"]
+
+# Constants
+BATCH_SIZE = 1000
+REVERT_PHASES = (
+    (AdditionalSignReal, "deactivate"),
+    (AdditionalSignReal, "update"),
+    (AdditionalSignReal, "create"),
+    (SignpostReal, "deactivate"),
+    (SignpostReal, "update"),
+    (SignpostReal, "create"),
+    (TrafficSignReal, "deactivate"),
+    (TrafficSignReal, "update"),
+    (TrafficSignReal, "create"),
+    (MountReal, "deactivate"),
+    (MountReal, "update"),
+    (MountReal, "create"),
+)
+model_class_map = {model.__name__: model for model, _ in REVERT_PHASES}
+
+
+class SplitStringsAction(argparse.Action):
+    """Argparse Action to transform a "foo,bar,baz" argument into ["foo", "bar", "baz"]."""
+
+    def __call__(self, parser, namespace, values, option_strings=None):
+        setattr(namespace, self.dest, values.split(","))
+
+
+class Command(BaseCommand):
+    help = "Revert the effects of an import_streetscan_signs_v2 run"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--dry-run",
+            help="Dry run",
+            action="store_true",
+            default=False,
+        )
+        parser.add_argument(
+            "-f",
+            "--file",
+            help="Revert jsonl file produced by an import operation",
+            required=True,
+            metavar="FILE",
+            dest="file_path",
+            type=str,
+        )
+        parser.add_argument(
+            "--ids",
+            help="Filter UUIDs to be reverted, separated by comma. If omitted then any UUID may be reverted.",
+            default=[],
+            action=SplitStringsAction,
+        )
+        parser.add_argument(
+            "--models",
+            help=(
+                "Models to be reverted, separated by comma. Default: "
+                "AdditionalSignReal,MountReal,SignpostReal,TrafficSignReal"
+            ),
+            default=["AdditionalSignReal", "MountReal", "SignpostReal", "TrafficSignReal"],
+            dest="model_names",
+            action=SplitStringsAction,
+        )
+        parser.epilog = (
+            "Note: When running a partial revert, the revert operation may bring more models or objects to the "
+            "the operation. For example if a mount created by an import operation is removed, all objects that had "
+            "their mount set to that object will be reverted as well. These side-effect reversals cascade to any "
+            "dependent objects."
+        )
+
+    def handle(
+        self,
+        *,
+        dry_run: bool,
+        file_path: str,
+        ids: list[str],
+        model_names: list[str],
+        **_kwargs: dict,
+    ) -> None:
+        timestamp = timezone.now()
+        user = get_system_user()
+        if dry_run:
+            self.stdout.write("Running in --dry-run mode, all operations will be reverted at the end of the process")
+
+        self.stdout.write(f"Models to revert: {', '.join(model_names)}")
+        self.stdout.write(f"Object IDs to revert: {', '.join(ids) if ids else 'all'}")
+
+        # [MODEL][ACTION_TYPE] -> [...ACTIONS]
+        actions_by_model_and_action_type: dict[type[ModelAffectedByImport], dict[str, list]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        # [MODEL][PK] -> UPDATE_ACTION
+        update_by_model_and_pk: dict[type[ModelAffectedByImport], dict[str, dict[str, str]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+
+        with open(file_path, "rt") as file:
+            for line in file:
+                if line:
+                    row = json.loads(line)
+                    action_type = row["action"]
+                    model = model_class_map.get(row["object_type"])
+                    actions_by_model_and_action_type[model][action_type].append(row)
+                    if action_type == "update":
+                        pk = row["db_id"]
+                        update_by_model_and_pk[model][pk] = row
+
+        revert_models = [apps.get_model("traffic_control", model_name) for model_name in model_names]
+        orphaned_pks_per_model: dict[type[ModelAffectedByImport], set[str]] = {
+            AdditionalSignReal: set(),
+            SignpostReal: set(),
+            TrafficSignReal: set(),
+        }
+        with set_actor(user), transaction.atomic():
+            # Phase A: Revert direct actions and collect orphaned objects
+            for model, action_type in REVERT_PHASES:
+                if model not in revert_models:
+                    continue
+                actions = actions_by_model_and_action_type[model][action_type]
+                actions.reverse()
+                self.stdout.write(f"Reverting {len(actions)} {action_type} operations for {model.__name__}...")
+                new_orphaned_pks_per_model = self.reverse_actions(
+                    model=model,
+                    action_type=action_type,
+                    actions=actions,
+                    limit_to_pks=ids,
+                    user=user,
+                    timestamp=timestamp,
+                )
+                for key, values in new_orphaned_pks_per_model.items():
+                    orphaned_pks_per_model[key].update(values)
+
+            # Phase B: Process objects orphaned by reverted actions
+            self.revert_updates_on_orphaned_objects(
+                orphaned_pks_per_model=orphaned_pks_per_model,
+                update_by_model_and_pk=update_by_model_and_pk,
+                user=user,
+                timestamp=timestamp,
+            )
+
+            if dry_run:
+                self.stdout.write("Running in --dry-run mode, cancelling transaction.")
+                transaction.set_rollback(True)
+
+    def reverse_actions(
+        self,
+        *,
+        model: ModelAffectedByImport,
+        action_type: ActionType,
+        actions: list[dict],
+        limit_to_pks: list[str],
+        user: User,
+        timestamp: datetime,
+    ) -> dict[type[ModelAffectedByImport], set[str]]:
+        """Revert a set of actions on a model
+
+        Returns: A map of primary key of orphaned object per model (in the case of "create" operations."""
+        if len(actions) == 0:
+            return {}
+
+        if action_type == "create":
+            if limit_to_pks:
+                pks = {action["db_id"] for action in actions if action["db_id"] in limit_to_pks}
+            else:
+                pks = {action["db_id"] for action in actions}
+            orphaned_pks_by_model = Command.detach_dependent_objects(model=model, pks=pks)
+            deleted_qs = model.objects.filter(pk__in=pks)
+            deleted_pks = {str(pk) for pk in deleted_qs.values_list("pk", flat=True)}
+            deleted_qs.delete()
+            missing_pks = pks - deleted_pks
+            for pk in missing_pks:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"{model.__name__} {pk} does not exist, unable to revert {action_type} operation"
+                    )
+                )
+            return orphaned_pks_by_model
+
+        entries = []
+        if action_type in ["update", "deactivate"]:
+            for action in actions:
+                pk = action["db_id"]
+                if limit_to_pks and pk not in limit_to_pks:
+                    continue
+                try:
+                    entry = model.objects.get(pk=pk)
+                    self.revert_update(entry=entry, row=action, timestamp=timestamp, user=user)
+                    entries.append(entry)
+                except model.DoesNotExist:
+                    pk = action["db_id"]
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"{model.__name__} {pk} does not exist, unable to revert {action_type} operation"
+                        )
+                    )
+                    continue
+        fields = set(actions[0]["old"]) | {"updated_by", "updated_at"}
+        model.objects.bulk_update(entries, fields, BATCH_SIZE)
+        return {}
+
+    @staticmethod
+    def revert_update(*, entry: ModelAffectedByImport, row: dict, timestamp: datetime, user: User) -> None:
+        """Restores previous field values and updates audit metadata."""
+        for field, value in row["old"].items():
+            setattr(entry, field, value)
+        entry.updated_by = user
+        entry.updated_at = timestamp
+
+    @staticmethod
+    def detach_dependent_objects(
+        *, model: ModelAffectedByImport, pks: set[str]
+    ) -> dict[type[ModelAffectedByImport], set[str]]:
+        """Clear assignments to the given items in the model before deletion.
+
+        Returns: Sets of dependent objects by model that need to have their update operations reverted."""
+        additional_sign_pks = set()
+        signpost_pks = set()
+        traffic_sign_pks = set()
+
+        if model == MountReal:
+            additional_qs = AdditionalSignReal.objects.filter(mount_real__pk__in=pks)
+            signpost_qs = SignpostReal.objects.filter(mount_real__pk__in=pks)
+            traffic_qs = TrafficSignReal.objects.filter(mount_real__pk__in=pks)
+
+            additional_sign_pks = set(additional_qs.values_list("pk", flat=True))
+            signpost_pks = set(signpost_qs.values_list("pk", flat=True))
+            traffic_sign_pks = set(traffic_qs.values_list("pk", flat=True))
+
+            additional_qs.update(mount_real=None)
+            signpost_qs.update(mount_real=None)
+            traffic_qs.update(mount_real=None)
+
+        elif model == SignpostReal:
+            additional_qs = AdditionalSignReal.objects.filter(signpost_real__pk__in=pks)
+            signpost_qs = SignpostReal.objects.filter(parent__pk__in=pks)
+
+            additional_sign_pks = set(additional_qs.values_list("pk", flat=True))
+            signpost_pks = set(signpost_qs.values_list("pk", flat=True))
+
+            additional_qs.update(signpost_real=None)
+            signpost_qs.update(parent=None)
+
+        elif model == TrafficSignReal:
+            additional_qs = AdditionalSignReal.objects.filter(parent__pk__in=pks)
+
+            additional_sign_pks = set(additional_qs.values_list("pk", flat=True))
+
+            additional_qs.update(parent=None)
+
+        return {
+            AdditionalSignReal: {str(pk) for pk in additional_sign_pks},
+            SignpostReal: {str(pk) for pk in signpost_pks},
+            TrafficSignReal: {str(pk) for pk in traffic_sign_pks},
+        }
+
+    def revert_updates_on_orphaned_objects(
+        self,
+        orphaned_pks_per_model: dict[type[ModelAffectedByImport], set[str]],
+        update_by_model_and_pk: dict[type[ModelAffectedByImport], dict[str, dict[str, str]]],
+        user: User,
+        timestamp: datetime,
+    ) -> None:
+        """Handles the final updates for secondary objects affected by reverted creates."""
+        for model, pks in orphaned_pks_per_model.items():
+            # We need to force a last update for secondary objects that have been affected by reverted create (left
+            # operator of intersection) and have an available update operation to be reverted (right operator of
+            # intersection)
+            revertible_orphaned_pks = pks & set(update_by_model_and_pk[model])
+            non_revertible_orphaned_pks = pks - revertible_orphaned_pks
+
+            if non_revertible_orphaned_pks:
+                sorted_pks = ", ".join(sorted(non_revertible_orphaned_pks))
+                self.stdout.write(
+                    f"{len(non_revertible_orphaned_pks)} secondary {model.__name__} objects orphaned by reverted "
+                    f"CREATE operations do not have pending UPDATE operations and cannot be reverted: "
+                    f"{sorted_pks}"
+                )
+
+            entries = model.objects.filter(
+                pk__in=revertible_orphaned_pks,
+                updated_at__lt=timestamp,  # Skip anything we have already updated during this revert operation
+            )
+            if len(entries) == 0:
+                self.stdout.write(
+                    f"No secondary {model.__name__} objects orphaned by reverted CREATE operations have pending "
+                    "UPDATE operations to be reverted."
+                )
+                continue
+            self.stdout.write(
+                f"{len(entries)} secondary {model.__name__} objects orphaned by reverted CREATE operations have "
+                "pending UPDATE operations to be reverted."
+            )
+
+            for entry in entries:
+                row = update_by_model_and_pk[model][str(entry.pk)]
+                self.revert_update(entry=entry, row=row, timestamp=timestamp, user=user)
+            fields = set(update_by_model_and_pk[model][list(revertible_orphaned_pks)[0]]["old"]) | {
+                "updated_by",
+                "updated_at",
+            }
+            model.objects.bulk_update(entries, fields, BATCH_SIZE)

--- a/traffic_control/signal_utils.py
+++ b/traffic_control/signal_utils.py
@@ -31,16 +31,16 @@ def generate_pngs_on_svg_save(*, instance, png_folder):
             try:
                 png_data = cairosvg.svg2png(bytestring=svg_bytestring, output_width=size, output_height=size)
             except Exception as e:
-                logger.error(f"Unable to convert {png_file_name} to PNG: {e}")
+                logger.error("Unable to convert %s to PNG: %s", png_file_name, e)
                 return
             try:
                 png_file_content = ContentFile(png_data)
                 instance.file.storage.save(png_file_path, png_file_content)
             except Exception as e:
-                logger.error(f"Unable to store {png_file_path}: {e}")
+                logger.error("Unable to store %s: %s", png_file_path, e)
                 return
 
-            logger.info(f"PNG icon generated: {png_file_path}")
+            logger.debug("PNG icon generated: %s", png_file_path)
 
 
 def delete_icon_files_on_row_delete(*, instance, png_folder):
@@ -60,16 +60,16 @@ def delete_icon_files_on_row_delete(*, instance, png_folder):
                 if instance.file.storage.exists(png_file_path):
                     try:
                         instance.file.storage.delete(png_file_path)
-                        logger.info(f"PNG file deleted: {png_file_path}")
+                        logger.debug("PNG file deleted: %s", png_file_path)
                     except Exception as e:
-                        logger.error(f"Unable to delete {png_file_path}: {e}")
+                        logger.error("Unable to delete %s: %s", png_file_path, e)
 
             # Delete the main SVG file
             instance.file.storage.delete(instance.file.name)
-            logger.info(f"SVG file deleted: {instance.file.name}")
+            logger.debug("SVG file deleted: %s", instance.file.name)
 
     except Exception as e:
-        logger.error(f"Error deleting files for instance {instance.pk}: {e}")
+        logger.error("Error deleting files for instance %s: %s", instance.pk, e)
 
 
 def _create_parent_log_entry(parent, message, action=None):
@@ -87,9 +87,9 @@ def _create_parent_log_entry(parent, message, action=None):
             action=action,
             changes=changes,
         )
-        logger.info(f"Successfully created log entry for {parent}: {message}")
+        logger.debug("Successfully created log entry for %s: %s", parent, message)
     except Exception as e:
-        logger.error(f"Failed to create log entry for {parent}: {e}", exc_info=True)
+        logger.error("Failed to create log entry for %s: %s", parent, e, exc_info=True)
 
 
 def _fetch_old_parent_value(sender, instance, parent_field_name, using):
@@ -98,7 +98,7 @@ def _fetch_old_parent_value(sender, instance, parent_field_name, using):
         db_instance = sender._default_manager.using(using).only("pk", parent_field_name).get(pk=instance.pk)
         return getattr(db_instance, parent_field_name)
     except sender.DoesNotExist:
-        logger.warning(f"Could not find {sender.__name__} pk={instance.pk} in database during pre_save")
+        logger.warning("Could not find %s pk=%s in database during pre_save", sender.__name__, instance.pk)
         return None
 
 
@@ -121,8 +121,8 @@ def create_auditlog_signals_for_parent_model(child_model, parent_field_name):
             old_parent_value = _fetch_old_parent_value(sender, instance, parent_field_name, using)
             setattr(instance, cache_attr, old_parent_value)
             if old_parent_value:
-                logger.info(
-                    f"Cached old {parent_field_name} for {sender.__name__} pk={instance.pk}: {old_parent_value}"
+                logger.debug(
+                    "Cached old %s for %s pk=%s: %s", parent_field_name, sender.__name__, instance.pk, old_parent_value
                 )
         else:
             # New instance, no old parent
@@ -132,15 +132,19 @@ def create_auditlog_signals_for_parent_model(child_model, parent_field_name):
         old_parent = getattr(instance, cache_attr, None)
         new_parent = getattr(instance, parent_field_name)
 
-        logger.info(
-            f"log_parent_change for {sender.__name__} pk={instance.pk}: "
-            f"created={created}, old_parent={old_parent}, new_parent={new_parent}"
+        logger.debug(
+            "log_parent_change for %s pk=%s: created=%s, old_parent=%s, new_parent=%s",
+            sender.__name__,
+            instance.pk,
+            created,
+            old_parent,
+            new_parent,
         )
 
         # Log removal from the old parent if the parent has changed
         if not created and old_parent and old_parent != new_parent:
             message = f"{child_model_name} '{instance}' was removed."
-            logger.info(f"Creating removal log entry: {message} for {old_parent}")
+            logger.debug("Creating removal log entry: %s for %s", message, old_parent)
             _create_parent_log_entry(old_parent, message)
 
         # Log addition or update to the new parent
@@ -151,7 +155,7 @@ def create_auditlog_signals_for_parent_model(child_model, parent_field_name):
                 if is_new_relation
                 else f"{child_model_name} '{instance}' was updated."
             )
-            logger.info(f"Creating log entry for parent {new_parent}: {message}")
+            logger.debug("Creating log entry for parent %s: %s", new_parent, message)
             _create_parent_log_entry(new_parent, message)
 
     def log_parent_deletion(sender, instance, **kwargs):
@@ -160,7 +164,7 @@ def create_auditlog_signals_for_parent_model(child_model, parent_field_name):
 
         if parent:
             message = f"{child_model_name} '{instance}' was removed."
-            logger.info(f"Creating deletion log entry: {message} for {parent}")
+            logger.debug("Creating deletion log entry: %s for %s", message, parent)
             _create_parent_log_entry(parent, message)
 
     pre_save.connect(

--- a/traffic_control/tests/management/commands/test_revert_import_streetscan_signs_v2.py
+++ b/traffic_control/tests/management/commands/test_revert_import_streetscan_signs_v2.py
@@ -1,0 +1,463 @@
+import json
+from datetime import datetime, timezone
+
+import pytest
+from django.core.management import call_command
+
+from traffic_control.models import (
+    AdditionalSignReal,
+    MountReal,
+    SignpostReal,
+    TrafficSignReal,
+)
+from traffic_control.tests.factories import (
+    AdditionalSignRealFactory,
+    MountRealFactory,
+    SignpostRealFactory,
+    TrafficSignRealFactory,
+    UserFactory,
+)
+
+# Test Constants
+UUID_1 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+UUID_2 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+UUID_3 = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+UUID_4 = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+UUID_5 = "00000000-0000-0000-0000-000000000000"
+UUID_6 = "11111111-1111-1111-1111-111111111111"
+UUID_7 = "22222222-2222-2222-2222-222222222222"
+UUID_8 = "33333333-3333-3333-3333-333333333333"
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def base_time_created():
+    return datetime(2021, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def base_time_updated():
+    return datetime(2022, 2, 2, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def user():
+    return UserFactory(
+        email="erkki.esimerkki@example.com",
+        first_name="Erkki",
+        last_name="Esimerkki",
+        username="erkki_esimerkki",
+    )
+
+
+def write_jsonl(tmp_path, rows: list[dict]) -> str:
+    """Helper to write a list of dicts to a JSONL file and return the file path."""
+    file_path = tmp_path / "revert.jsonl"
+    with open(file_path, "wt") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+    return file_path
+
+
+# --- Test Cases ---
+
+
+@pytest.mark.django_db
+def test_no_objects_affected_in_db(tmp_path, capsys, user, base_time_created, base_time_updated):
+    """Objects exist in DB, but no objects exist that match the revert file."""
+    mount = MountRealFactory(id=UUID_1, created_by=user, updated_by=user)
+    signpost = SignpostRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1)
+    traffic_sign = TrafficSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1)
+    additional_sign = AdditionalSignRealFactory(id=UUID_4, created_by=user, updated_by=user, condition=1)
+
+    MountReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    SignpostReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+    AdditionalSignReal.objects.filter(id=UUID_4).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "update", "object_type": "MountReal", "db_id": UUID_5, "old": {"mount_type_id": UUID_1}},
+            {"action": "update", "object_type": "SignpostReal", "db_id": UUID_6, "old": {"condition": 5}},
+            {"action": "deactivate", "object_type": "TrafficSignReal", "db_id": UUID_7, "old": {"condition": 5}},
+            {"action": "create", "object_type": "AdditionalSignReal", "db_id": UUID_8},
+        ],
+    )
+
+    call_command("revert_import_streetscan_signs_v2", file_path=file_path)
+
+    additional_sign.refresh_from_db()
+    mount.refresh_from_db()
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+
+    assert additional_sign.condition == 1
+    assert signpost.condition == 1
+    assert traffic_sign.condition == 1
+
+    assert additional_sign.updated_at == base_time_updated
+    assert mount.updated_at == base_time_updated
+    assert signpost.updated_at == base_time_updated
+    assert traffic_sign.updated_at == base_time_updated
+
+    captured = capsys.readouterr()
+    assert (
+        "AdditionalSignReal 33333333-3333-3333-3333-333333333333 does not exist, unable to revert create operation"
+        in captured.out
+    )
+    assert (
+        "SignpostReal 11111111-1111-1111-1111-111111111111 does not exist, unable to revert update operation"
+        in captured.out
+    )
+    assert (
+        "TrafficSignReal 22222222-2222-2222-2222-222222222222 does not exist, unable to revert deactivate operation"
+        in captured.out
+    )
+    assert (
+        "MountReal 00000000-0000-0000-0000-000000000000 does not exist, unable to revert update operation"
+        in captured.out
+    )
+
+
+@pytest.mark.django_db
+def test_objects_exist_none_affected_due_to_cli_filter(tmp_path, user, base_time_created, base_time_updated):
+    """Objects exist and match the file, but CLI arguments filter them out entirely."""
+    signpost = SignpostRealFactory(id=UUID_1, created_by=user, updated_by=user, condition=1)
+    traffic_sign = TrafficSignRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1)
+    additional_sign = AdditionalSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1)
+
+    SignpostReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    AdditionalSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "update", "object_type": "SignpostReal", "db_id": UUID_1, "old": {"condition": 5}},
+            {"action": "update", "object_type": "TrafficSignReal", "db_id": UUID_2, "old": {"condition": 5}},
+            {"action": "update", "object_type": "AdditionalSignReal", "db_id": UUID_3, "old": {"condition": 5}},
+        ],
+    )
+
+    call_command("revert_import_streetscan_signs_v2", file_path=file_path, ids=[UUID_4])
+
+    additional_sign.refresh_from_db()
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+
+    assert additional_sign.condition == 1
+    assert signpost.condition == 1
+    assert traffic_sign.condition == 1
+
+    assert additional_sign.updated_at == base_time_updated
+    assert signpost.updated_at == base_time_updated
+    assert traffic_sign.updated_at == base_time_updated
+
+
+@pytest.mark.django_db
+def test_objects_exist_partially_affected_due_to_id_filter(tmp_path, user, base_time_created, base_time_updated):
+    """Objects exist, but only some are affected due to CLI ID filter."""
+    signpost = SignpostRealFactory(id=UUID_1, created_by=user, updated_by=user, condition=1)
+    traffic_sign = TrafficSignRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1)
+    additional_sign = AdditionalSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1)
+
+    SignpostReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    AdditionalSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "update", "object_type": "SignpostReal", "db_id": UUID_1, "old": {"condition": 5}},
+            {"action": "update", "object_type": "TrafficSignReal", "db_id": UUID_2, "old": {"condition": 5}},
+            {"action": "update", "object_type": "AdditionalSignReal", "db_id": UUID_3, "old": {"condition": 5}},
+        ],
+    )
+
+    call_command("revert_import_streetscan_signs_v2", file_path=file_path, ids=[UUID_1, UUID_3])
+
+    additional_sign.refresh_from_db()
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+
+    assert additional_sign.condition == 5
+    assert additional_sign.updated_at > base_time_updated
+
+    assert signpost.condition == 5
+    assert signpost.updated_at > base_time_updated
+
+    assert traffic_sign.condition == 1
+    assert traffic_sign.updated_at == base_time_updated
+
+
+@pytest.mark.django_db
+def test_objects_exist_partially_affected_due_to_model_filter(tmp_path, user, base_time_created, base_time_updated):
+    """Objects exist, but only some are affected due to CLI model filter."""
+    signpost = SignpostRealFactory(id=UUID_1, created_by=user, updated_by=user, condition=1)
+    traffic_sign = TrafficSignRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1)
+    additional_sign = AdditionalSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1)
+
+    SignpostReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    AdditionalSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "update", "object_type": "SignpostReal", "db_id": UUID_1, "old": {"condition": 5}},
+            {"action": "update", "object_type": "TrafficSignReal", "db_id": UUID_2, "old": {"condition": 5}},
+            {"action": "update", "object_type": "AdditionalSignReal", "db_id": UUID_3, "old": {"condition": 5}},
+        ],
+    )
+
+    call_command(
+        "revert_import_streetscan_signs_v2", file_path=file_path, models=["AdditionalSignReal", "TrafficSignReal"]
+    )
+
+    additional_sign.refresh_from_db()
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+
+    assert additional_sign.condition == 5
+    assert additional_sign.updated_at > base_time_updated
+
+    assert traffic_sign.condition == 5
+    assert traffic_sign.updated_at > base_time_updated
+
+    assert signpost.condition == 1
+    assert signpost.updated_at == base_time_updated
+
+
+@pytest.mark.django_db
+def test_objects_exist_partially_affected_due_to_both_filters(tmp_path, user, base_time_created, base_time_updated):
+    """Objects exist, but only some are affected due to CLI model and ID filters."""
+    signpost = SignpostRealFactory(id=UUID_1, created_by=user, updated_by=user, condition=1)
+    traffic_sign = TrafficSignRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1)
+    additional_sign = AdditionalSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1)
+
+    SignpostReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    AdditionalSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "update", "object_type": "SignpostReal", "db_id": UUID_1, "old": {"condition": 5}},
+            {"action": "update", "object_type": "TrafficSignReal", "db_id": UUID_2, "old": {"condition": 5}},
+            {"action": "update", "object_type": "AdditionalSignReal", "db_id": UUID_3, "old": {"condition": 5}},
+        ],
+    )
+
+    call_command(
+        "revert_import_streetscan_signs_v2",
+        file_path=file_path,
+        models=["AdditionalSignReal", "TrafficSignReal"],
+        ids=[UUID_1, UUID_3],
+    )
+
+    additional_sign.refresh_from_db()
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+
+    assert additional_sign.condition == 5
+    assert additional_sign.updated_at > base_time_updated
+    assert traffic_sign.condition == 1
+    assert signpost.condition == 1
+
+
+@pytest.mark.django_db
+def test_objects_affected_no_orphans(tmp_path, capsys, user, base_time_created, base_time_updated):
+    """Standard revert affecting objects without producing dependents/orphans."""
+    signpost = SignpostRealFactory(id=UUID_1, created_by=user, updated_by=user, condition=1)
+    traffic_sign = TrafficSignRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1)
+    additional_sign = AdditionalSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1)
+
+    SignpostReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    AdditionalSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "update", "object_type": "SignpostReal", "db_id": UUID_1, "old": {"condition": 5}},
+            {"action": "update", "object_type": "TrafficSignReal", "db_id": UUID_2, "old": {"condition": 5}},
+            {"action": "update", "object_type": "AdditionalSignReal", "db_id": UUID_3, "old": {"condition": 5}},
+        ],
+    )
+
+    call_command("revert_import_streetscan_signs_v2", file_path=file_path)
+
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+    additional_sign.refresh_from_db()
+
+    assert signpost.condition == 5
+    assert traffic_sign.condition == 5
+    assert additional_sign.condition == 5
+
+    captured = capsys.readouterr()
+    assert "No secondary AdditionalSignReal objects orphaned" in captured.out
+    assert "No secondary SignpostReal objects orphaned" in captured.out
+    assert "No secondary TrafficSignReal objects orphaned" in captured.out
+
+
+@pytest.mark.django_db
+def test_orphans_produced_and_included_in_revert_file(tmp_path, capsys, user, base_time_created, base_time_updated):
+    """Reverting a mount and a signpost creation leaves dependent signs orphaned, and their subsequent update records
+    are bypassed by the initial CLI model filter but successfully processed by Phase B."""
+    mount = MountRealFactory(id=UUID_1, created_by=user, updated_by=user)
+    signpost = SignpostRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1, mount_real=mount)
+    traffic_sign = TrafficSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1, mount_real=mount)
+    additional_sign = AdditionalSignRealFactory(
+        id=UUID_4, created_by=user, updated_by=user, condition=1, signpost_real=signpost
+    )
+
+    MountReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    SignpostReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+    AdditionalSignReal.objects.filter(id=UUID_4).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "create", "object_type": "MountReal", "db_id": UUID_1},
+            {"action": "create", "object_type": "SignpostReal", "db_id": UUID_2},
+            {"action": "update", "object_type": "TrafficSignReal", "db_id": UUID_3, "old": {"condition": 5}},
+            {"action": "update", "object_type": "AdditionalSignReal", "db_id": UUID_4, "old": {"condition": 5}},
+        ],
+    )
+
+    call_command("revert_import_streetscan_signs_v2", file_path=file_path, models=["MountReal", "SignpostReal"])
+
+    assert not MountReal.objects.filter(id=UUID_1).exists()
+    assert not SignpostReal.objects.filter(id=UUID_2).exists()
+
+    traffic_sign.refresh_from_db()
+    additional_sign.refresh_from_db()
+
+    assert traffic_sign.mount_real is None
+    assert traffic_sign.condition == 5
+
+    assert additional_sign.signpost_real is None
+    assert additional_sign.condition == 5
+
+    captured = capsys.readouterr()
+    assert "1 secondary TrafficSignReal objects orphaned" in captured.out
+    assert "1 secondary AdditionalSignReal objects orphaned" in captured.out
+
+
+@pytest.mark.django_db
+def test_orphans_produced_and_excluded_by_cli_filter(tmp_path, capsys, user, base_time_created, base_time_updated):
+    """Reverting creation files leaves child records orphaned; the child updates are bypassed by the CLI id filters,
+    but processed completely by Phase B fallback."""
+    mount = MountRealFactory(id=UUID_1, created_by=user, updated_by=user)
+    signpost = SignpostRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1, mount_real=mount)
+    traffic_sign = TrafficSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1, mount_real=mount)
+
+    MountReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    SignpostReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "create", "object_type": "MountReal", "db_id": UUID_1},
+            {"action": "update", "object_type": "SignpostReal", "db_id": UUID_2, "old": {"condition": 5}},
+            {"action": "update", "object_type": "TrafficSignReal", "db_id": UUID_3, "old": {"condition": 5}},
+        ],
+    )
+
+    call_command("revert_import_streetscan_signs_v2", file_path=file_path, ids=[UUID_1])
+
+    assert not MountReal.objects.filter(id=UUID_1).exists()
+
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+
+    assert signpost.mount_real is None
+    assert signpost.condition == 5
+
+    assert traffic_sign.mount_real is None
+    assert traffic_sign.condition == 5
+
+    captured = capsys.readouterr()
+    assert "1 secondary SignpostReal objects orphaned" in captured.out
+    assert "1 secondary TrafficSignReal objects orphaned" in captured.out
+
+
+@pytest.mark.django_db
+def test_orphans_produced_and_never_mentioned_in_revert_file(
+    tmp_path, capsys, user, base_time_created, base_time_updated
+):
+    """Reverting a container leaves child components orphaned, but because they have no update data in the log, their
+    attributes remain un-reverted, and a specific fallback missing update string is emitted to standard output."""
+    mount = MountRealFactory(id=UUID_1, created_by=user, updated_by=user)
+    signpost = SignpostRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1, mount_real=mount)
+    traffic_sign = TrafficSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1, mount_real=mount)
+
+    MountReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    SignpostReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(tmp_path, [{"action": "create", "object_type": "MountReal", "db_id": UUID_1}])
+
+    call_command("revert_import_streetscan_signs_v2", file_path=file_path)
+
+    assert not MountReal.objects.filter(id=UUID_1).exists()
+
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+
+    assert signpost.mount_real is None
+    assert signpost.condition == 1
+
+    assert traffic_sign.mount_real is None
+    assert traffic_sign.condition == 1
+
+    captured = capsys.readouterr()
+    # Validate the fallback TODO implementation log structure
+    assert (
+        "1 secondary SignpostReal objects orphaned by reverted CREATE operations do not have pending UPDATE "
+        f"operations and cannot be reverted: {UUID_2}"
+    ) in captured.out
+    assert (
+        "1 secondary TrafficSignReal objects orphaned by reverted CREATE operations do not have pending UPDATE "
+        f"operations and cannot be reverted: {UUID_3}"
+    ) in captured.out
+
+
+@pytest.mark.django_db
+def test_dry_run(tmp_path, user, base_time_created, base_time_updated):
+    """A dry run handles operations fully but transactions are rolled back leaving objects unchanged."""
+    signpost = SignpostRealFactory(id=UUID_1, created_by=user, updated_by=user, condition=1)
+    traffic_sign = TrafficSignRealFactory(id=UUID_2, created_by=user, updated_by=user, condition=1)
+    additional_sign = AdditionalSignRealFactory(id=UUID_3, created_by=user, updated_by=user, condition=1)
+
+    SignpostReal.objects.filter(id=UUID_1).update(updated_at=base_time_updated, created_at=base_time_created)
+    TrafficSignReal.objects.filter(id=UUID_2).update(updated_at=base_time_updated, created_at=base_time_created)
+    AdditionalSignReal.objects.filter(id=UUID_3).update(updated_at=base_time_updated, created_at=base_time_created)
+
+    file_path = write_jsonl(
+        tmp_path,
+        [
+            {"action": "update", "object_type": "SignpostReal", "db_id": UUID_1, "old": {"condition": 5}},
+            {"action": "update", "object_type": "TrafficSignReal", "db_id": UUID_2, "old": {"condition": 5}},
+            {"action": "update", "object_type": "AdditionalSignReal", "db_id": UUID_3, "old": {"condition": 5}},
+        ],
+    )
+
+    call_command("revert_import_streetscan_signs_v2", file_path=file_path, dry_run=True)
+
+    signpost.refresh_from_db()
+    traffic_sign.refresh_from_db()
+    additional_sign.refresh_from_db()
+
+    assert signpost.condition == 1
+    assert traffic_sign.condition == 1
+    assert additional_sign.condition == 1
+    assert signpost.updated_at == base_time_updated
+    assert traffic_sign.updated_at == base_time_updated
+    assert additional_sign.updated_at == base_time_updated

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,7 +1,7 @@
 from .models import User
 
 
-def get_system_user():
+def get_system_user() -> User:
     user, _ = User.objects.get_or_create(
         username="system",
         is_active=False,


### PR DESCRIPTION
    feat: Revert operation for import Streetscan2025 v2 command
    
    - Filter by IDs
    - Filter by Model
    - Using both filters excludes any IDs not mentioned AND models not mentioned
    - Objects orphaned by reverted CREATE operations have their UPDATE operations
      reverted (if an UPDATE operation is available in the reverts file)
    
    Refs: LIIK-968
