### PR TITLE
refactor: Alter plan bulk insert request format

### DIFF
--- a/traffic_control/static/traffic_control/openapi/openapi.yaml
+++ b/traffic_control/static/traffic_control/openapi/openapi.yaml
@@ -17458,10 +17458,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BulkPlanInputSerializerMountPlanItemRequest'
-        plans:
-          type: array
-          items:
-            $ref: '#/components/schemas/BulkPlanInputSerializerPlanItemRequest'
+        plan:
+          $ref: '#/components/schemas/BulkPlanInputSerializerPlanItemRequest'
         signpost_plans:
           type: array
           items:
@@ -17471,7 +17469,7 @@ components:
           items:
             $ref: '#/components/schemas/BulkPlanInputSerializerTrafficSignPlanItemRequest'
       required:
-      - plans
+      - plan
     BulkPlanInputResponse:
       type: object
       properties:
@@ -17483,10 +17481,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MountPlanOutput'
-        plans:
-          type: array
-          items:
-            $ref: '#/components/schemas/Plan'
+        plan:
+          $ref: '#/components/schemas/Plan'
         signpost_plans:
           type: array
           items:
@@ -17496,7 +17492,7 @@ components:
           items:
             $ref: '#/components/schemas/TrafficSignPlanOutput'
       required:
-      - plans
+      - plan
     BulkPlanInputSerializerAdditionalSignPlanItemRequest:
       type: object
       description: |-

--- a/traffic_control/tests/test_plan_bulk_insert_api.py
+++ b/traffic_control/tests/test_plan_bulk_insert_api.py
@@ -87,7 +87,7 @@ def plan_payload(*, request_object_id=DEFAULT_PLAN_ID, **kwargs) -> dict:
         "drawing_numbers": [],
         "derive_location": True,
     }
-    result.update(**kwargs)
+    result.update(kwargs)
     return result
 
 
@@ -150,7 +150,7 @@ def _post_insert_plan_bulk(
     *,
     additional_sign_plans=None,
     mount_plans=None,
-    plans=None,
+    plan=None,
     signpost_plans=None,
     traffic_sign_plans=None,
 ):
@@ -159,8 +159,8 @@ def _post_insert_plan_bulk(
         payload_obj["additional_sign_plans"] = additional_sign_plans
     if mount_plans:
         payload_obj["mount_plans"] = mount_plans
-    if plans:
-        payload_obj["plans"] = plans
+    if plan:
+        payload_obj["plan"] = plan
     if signpost_plans:
         payload_obj["signpost_plans"] = signpost_plans
     if traffic_sign_plans:
@@ -224,7 +224,7 @@ def test_plan_bulk_insert_success(
             additional_sign_plan_payload(device_type=additional_sign_device_type.pk, owner=owner.pk)
         ],
         mount_plans=[mount_plan_payload(owner=owner.pk)],
-        plans=[plan_payload()],
+        plan=plan_payload(),
         signpost_plans=[signpost_plan_payload(device_type=signpost_sign_device_type.pk, owner=owner.pk)],
         traffic_sign_plans=[traffic_sign_plan_payload(device_type=traffic_sign_device_type.pk, owner=owner.pk)],
     )
@@ -236,14 +236,14 @@ def test_plan_bulk_insert_success(
     # Check that the returned objects are present in the response
     assert len(response_data.get("additional_sign_plans")) == 1, "Should create one additional sign plan"
     assert len(response_data.get("mount_plans")) == 1, "Should create one mount plan"
-    assert len(response_data.get("plans")) == 1, "Should create one plan"
+    assert "plan" in response_data, "Should include plan"
     assert len(response_data.get("signpost_plans")) == 1, "Should create one signpost plan"
     assert len(response_data.get("traffic_sign_plans")) == 1, "Should create one traffic sign plan"
 
     # Check that the returned objects have been created with the expected IDs
     assert response_data.get("additional_sign_plans")[0]["id"] == DEFAULT_ADDITIONAL_SIGN_PLAN_ID
     assert response_data.get("mount_plans")[0]["id"] == DEFAULT_MOUNT_PLAN_ID
-    assert response_data.get("plans")[0]["id"] == DEFAULT_PLAN_ID
+    assert response_data.get("plan")["id"] == DEFAULT_PLAN_ID
     assert response_data.get("signpost_plans")[0]["id"] == DEFAULT_SIGNPOST_PLAN_ID
     assert response_data.get("traffic_sign_plans")[0]["id"] == DEFAULT_TRAFFIC_SIGN_PLAN_ID
 
@@ -266,7 +266,7 @@ def test_plan_bulk_insert_is_atomic(
             additional_sign_plan_payload(device_type=additional_sign_device_type.pk, owner=owner.pk)
         ],
         mount_plans=[mount_plan_payload(owner="bogus-id")],
-        plans=[plan_payload()],
+        plan=plan_payload(),
         signpost_plans=[signpost_plan_payload(device_type=signpost_sign_device_type.pk, owner=owner.pk)],
         traffic_sign_plans=[traffic_sign_plan_payload(device_type=traffic_sign_device_type.pk, owner=owner.pk)],
     )
@@ -286,13 +286,13 @@ def test_plan_bulk_insert_single_object_validation_failure(admin_client):
     response = _post_insert_plan_bulk(
         admin_client,
         mount_plans=[mount_plan_payload(owner="bogus-id")],
-        plans=[plan_payload()],
+        plan=plan_payload(),
     )
     response_data = response.json()
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     # Assert that we only get a single complaint about mount plans and no other objects are mentioned in response
-    assert "plans" not in response_data, "Should not complain about plans"
+    assert "plan" not in response_data, "Should not complain about plan"
     assert len(response_data) == 1, "Response contains unexpected keys"
     assert len(response_data.get("mount_plans")) == 1, "Should have one mount plan complaint"
     assert "owner" in response_data["mount_plans"][0], "Complaint should be about the owner field"
@@ -305,7 +305,7 @@ def test_plan_bulk_insert_multiple_object_validation_failures(admin_client, owne
     response = _post_insert_plan_bulk(
         admin_client,
         mount_plans=[mount_plan_payload(owner="bogus-id")],
-        plans=[plan_payload()],
+        plan=plan_payload(),
         traffic_sign_plans=[
             traffic_sign_plan_payload(device_type="bogus-device-type-id", owner="another-bogus-id"),  # two complaints
             traffic_sign_plan_payload(device_type=traffic_sign_device_type.pk, owner=owner.pk),  # no complaints
@@ -342,7 +342,7 @@ def test_plan_bulk_insert_cycle_detected_failure(admin_client, owner, signpost_s
     # Assign both signposts' parent field to each other
     response = _post_insert_plan_bulk(
         admin_client,
-        plans=[plan_payload()],
+        plan=plan_payload(),
         signpost_plans=[
             signpost_plan_payload(
                 device_type=signpost_sign_device_type.pk,
@@ -379,16 +379,16 @@ def test_plan_bulk_insert_rejects_object_duplication(admin_client):  # (or datab
     # Attempt to create the object with the endpoint
     response = _post_insert_plan_bulk(
         admin_client,
-        plans=[plan_payload(request_object_id=DEFAULT_PLAN_ID)],
+        plan=plan_payload(request_object_id=DEFAULT_PLAN_ID),
     )
     response_data = response.json()
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     # Expect duplicate plan object complaint
-    assert "plans" in response_data, "Should complain about plans"
+    assert "plan" in response_data, "Should complain about plan"
     assert len(response_data) == 1, "Response contains unexpected keys"
-    assert DEFAULT_PLAN_ID in response_data.get("plans")[0], "Complaint should be about the duplicated plan object"
-    assert "duplicate" in response_data.get("plans")[0][DEFAULT_PLAN_ID], "Complaint should mention 'duplicate'"
+    assert DEFAULT_PLAN_ID in response_data.get("plan")[0], "Complaint should be about the duplicated plan object"
+    assert "duplicate" in response_data.get("plan")[0][DEFAULT_PLAN_ID], "Complaint should mention 'duplicate'"
 
 
 @pytest.mark.django_db
@@ -401,13 +401,13 @@ def test_plan_bulk_insert_announces_cascading_errors_neatly(admin_client, owner)
             mount_plan_payload(owner=owner.pk),
             mount_plan_payload(owner=owner.pk, request_object_id=ALT_MOUNT_PLAN_ID),
         ],
-        plans=[plan_payload(request_object_id=DEFAULT_PLAN_ID)],
+        plan=plan_payload(request_object_id=DEFAULT_PLAN_ID),
     )
     response_data = response.json()
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     # Expect both mount plans to fail
-    assert "plans" in response_data, "Should complain about plans"
+    assert "plan" in response_data, "Should complain about plan"
     assert "mount_plans" in response_data, "Should complain about mount plans"
     assert len(response_data) == 2, "Response contains unexpected keys"
 

--- a/traffic_control/views/bulk_plan_insert.py
+++ b/traffic_control/views/bulk_plan_insert.py
@@ -130,7 +130,7 @@ DEPENDENCY_ID_FIELDS = {"plan", "mount_plan", "parent", "signpost_plan"}
 class BulkPlanInputSerializer(serializers.Serializer):
     additional_sign_plans = BulkPlanInputSerializerAdditionalSignPlanItem(many=True, required=False, default=list)
     mount_plans = BulkPlanInputSerializerMountPlanItem(many=True, required=False, default=list)
-    plans = BulkPlanInputSerializerPlanItem(many=True, required=True)
+    plan = BulkPlanInputSerializerPlanItem(many=False, required=True)
     signpost_plans = BulkPlanInputSerializerSignpostPlanItem(many=True, required=False, default=list)
     traffic_sign_plans = BulkPlanInputSerializerTrafficSignPlanItem(many=True, required=False, default=list)
 
@@ -150,7 +150,10 @@ class BulkPlanInputSerializer(serializers.Serializer):
         # Build dependency graph and object type/data map
         sorter = graphlib.TopologicalSorter()
         for object_type in self.fields:
-            for object_data in attrs.get(object_type, []):
+            # Cast single-entry fields to arrays for uniform processing
+            entries_data = to_list(attrs.get(object_type, []))
+
+            for object_data in entries_data:
                 dependencies = []
                 for dependency_field in DEPENDENCY_ID_FIELDS:
                     if dependency_field in object_data and object_data[dependency_field]:
@@ -175,17 +178,18 @@ class BulkPlanInputSerializer(serializers.Serializer):
         Due to dependencies between objects being created, objects need to be created in topological order. The method
         may raise further validation errors if any objects fail creation along the way.
         """
-        created_objects_by_type = defaultdict(list)
+        created_objects_by_type = {}
         created_objects_by_pk = {}
 
         errors = defaultdict(list)
+        created_objects_by_type = defaultdict(list)
         with transaction.atomic():
             for object_id in self._object_topological_order:
                 try:
                     object_info = self._object_type_and_data_map[object_id]
                     object_type = object_info["type"]
                     object_data = object_info["data"]
-                    object_serializer = self.fields[object_type].child
+                    object_serializer, is_array = get_single_object_serializer(self.fields[object_type])
 
                     # NOTE (2026-06-25 thiago)
                     # Because django-rest-framework's object existence validation has been bypassed, we have to
@@ -198,7 +202,10 @@ class BulkPlanInputSerializer(serializers.Serializer):
                             object_data[dependency_field] = created_objects_by_pk[dependency_pk]
 
                     instance = object_serializer.create(object_data)
-                    created_objects_by_type[object_type].append(instance)
+                    if is_array:
+                        created_objects_by_type[object_type].append(instance)
+                    else:
+                        created_objects_by_type[object_type] = instance
                     created_objects_by_pk[instance.pk] = instance
                 except Exception as e:
                     errors[object_type].append({str(object_id): e})
@@ -211,6 +218,20 @@ class BulkPlanInputSerializer(serializers.Serializer):
 class BulkPlanInputResponseSerializer(serializers.Serializer):
     additional_sign_plans = AdditionalSignPlanOutputSerializer(many=True, required=False, default=list)
     mount_plans = MountPlanOutputSerializer(many=True, required=False, default=list)
-    plans = PlanSerializer(many=True, required=True)
+    plan = PlanSerializer(many=False, required=True)
     signpost_plans = SignpostPlanOutputSerializer(many=True, required=False, default=list)
     traffic_sign_plans = TrafficSignPlanOutputSerializer(many=True, required=False, default=list)
+
+
+def to_list(value) -> list:
+    if not isinstance(value, list):
+        return [value]
+    return value
+
+
+def get_single_object_serializer(
+    serializer_class: serializers.ModelSerializer,
+) -> tuple[serializers.ModelSerializer, bool]:
+    if hasattr(serializer_class, "child"):
+        return serializer_class.child, True
+    return serializer_class, False


### PR DESCRIPTION
plans: Plan[] -> plan: Plan

There is no current use case for the insertion of multiple Plan objects at once, being able to assume we have only one simplifies the endpoint.

This fix does no improvements to the format of the error messages.

Refs: LIIK-967